### PR TITLE
ACE support for medic points in ranked version

### DIFF
--- a/co30_Domination.Altis/x_client/x_f/fn_handleheal.sqf
+++ b/co30_Domination.Altis/x_client/x_f/fn_handleheal.sqf
@@ -1,24 +1,60 @@
-// by Xeno
+// by Xeno, ACE support by Auge
 //#define __DEBUG__
 #define THIS_FILE "fn_handleheal.sqf"
 #include "..\..\x_setup.sqf"
 
 if (isDedicated) exitWith {};
 
-params ["_healed", "_healer"];
-if (alive _healed && {alive _healer && {_healed != _healer && {!(_healed getVariable ["xr_pluncon", false]) && {!(_healer getVariable ["xr_pluncon", false])}}}}) then {
-	[_healed, _healer] spawn {
-		scriptName "spawn_handleheal";
-		params ["_healed", "_healer"];
-		sleep 3;
-		if (alive _healed && {alive _healer && {_healed != _healer && {!(_healed getVariable ["xr_pluncon", false]) && {!(_healer getVariable ["xr_pluncon", false])}}}}) then {
-			[_healer, d_ranked_a # 17] remoteExecCall ["addScore", 2];
-			if (isMultiplayer) then {
-				[[playerSide, "HQ"], format [localize "STR_DOM_MISSIONSTRING_288", d_ranked_a # 17]] remoteExecCall ["sideChat", _healer];
-			} else {
-				[playerSide, "HQ"] sideChat format [localize "STR_DOM_MISSIONSTRING_288", d_ranked_a # 17];
+if (!d_with_ace) then {
+	params ["_healed", "_healer"];
+	if (alive _healed && {alive _healer && {_healed != _healer && {!(_healed getVariable ["xr_pluncon", false]) && {!(_healer getVariable ["xr_pluncon", false])}}}}) then {
+		[_healed, _healer] spawn {
+			scriptName "spawn_handleheal";
+			params ["_healed", "_healer"];
+			sleep 3;
+			if (alive _healed && {alive _healer && {_healed != _healer && {!(_healed getVariable ["xr_pluncon", false]) && {!(_healer getVariable ["xr_pluncon", false])}}}}) then {
+				[_healer, d_ranked_a select 17] remoteExecCall ["addScore", 2];
+				if (isMultiplayer) then {
+					[[playerSide, "HQ"], format [localize "STR_DOM_MISSIONSTRING_288", d_ranked_a select 17]] remoteExecCall ["sideChat", _healer];
+				} else {
+					[playerSide, "HQ"] sideChat format [localize "STR_DOM_MISSIONSTRING_288", d_ranked_a select 17];
+				};
 			};
 		};
 	};
+	false
+} else {	
+	// Use ACE medical system
+	params ["_healer", "_healed", "_bodyPart", "_medicItem"];
+	private _medicPoints = 0;
+	
+	if (alive _healed && {alive _healer && {_healed != _healer && {!(_healed getVariable ["ace_isunconscious", false]) && {!(_healer getVariable ["ace_isunconscious", false])}}}}) then {
+		// Select points (You can add different cases in here to support multiple ace medical actions and distribute points accordingly) 
+		// This differentiates between "normal" soldiers and ace medics - medics who have set Ace_medical_medicClass to 1 or 2 can get different points
+		if ((!isNil {_healer getVariable "Ace_medical_medicClass"}) && {((_healer getVariable "Ace_medical_medicClass") > 0)}) then {
+			// Medic & Doctor point rewards
+			_medicPoints = switch (_medicItem) do {
+				case ("PersonalAidKit"): {d_ranked_a select 17};
+				default {0};
+			};
+		} else {
+			// Standard soldier point rewards
+			_medicPoints = switch (_medicItem) do {
+				case ("PersonalAidKit"): {d_ranked_a select 17};
+				default {0};
+			};
+		};
+		
+		// Add points to player
+		if (_medicPoints > 0) then {
+			[_healer, _medicPoints] remoteExecCall ["addScore", 2];
+			// Display chat message to player
+			if (isMultiplayer) then {
+				[[playerSide, "HQ"], format [localize "STR_DOM_MISSIONSTRING_288", _medicPoints]] remoteExecCall ["sideChat", _healer];
+			} else {
+				[playerSide, "HQ"] sideChat format [localize "STR_DOM_MISSIONSTRING_288", _medicPoints];
+			};
+		};
+	};
+	false
 };
-false

--- a/co30_Domination.Altis/x_client/x_setupplayer.sqf
+++ b/co30_Domination.Altis/x_client/x_setupplayer.sqf
@@ -191,6 +191,8 @@ if (d_with_ranked) then {
 	
 	if (!d_with_ace) then {
 		player addEventHandler ["handleHeal", {_this call d_fnc_handleheal}];
+	} else {
+		["ace_treatmentSucceded", { _this call d_fnc_handleheal}] call CBA_fnc_addEventHandler;
 	};
 	
 	d_sm_p_pos = nil;


### PR DESCRIPTION
This adds support for ranked medic points when ACE is enabled.
It is not only possible to distribute points in correlation to the used medical item, it is also possible to differentiate between soldiers and ACE medics/doctors, which have their very own points distribution.

To change the distribution, simply add cases to the switch statement with the corresponding ACE medic actions and change points.