### PR TITLE
Civilians on targets

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -723,13 +723,6 @@ class Params {
 		default = 120;
 		texts[] = {"$STR_DOM_MISSIONSTRING_363","60","120","300","600","1200","1800"};
 	};
-
-	class d_arty_unlimited {
-    		title = "$STR_DOM_MISSIONSTRING_1885";
-    		values[] = {0,1};
-    		default = 0;
-    		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_1006"};
-    };
 	
 	class d_enable_civs {
 			title = "$STR_DOM_MISSIONSTRING_1890";

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -724,6 +724,34 @@ class Params {
 		texts[] = {"$STR_DOM_MISSIONSTRING_363","60","120","300","600","1200","1800"};
 	};
 
+	class d_arty_unlimited {
+    		title = "$STR_DOM_MISSIONSTRING_1885";
+    		values[] = {0,1};
+    		default = 0;
+    		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_1006"};
+    };
+	
+	class d_enable_civs {
+			title = "$STR_DOM_MISSIONSTRING_1890";
+			values[] = {0,1};
+			default = 0;
+			texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_1006"};
+	};
+	
+	class d_civ_unitcount {
+			title = "$STR_DOM_MISSIONSTRING_1893";
+			values[] = {0,1,2,3,4,5,10,15,20,25,30};
+			default = 0;
+			texts[] = {"0","1","2","3","4","5","10","15","20","25","30"};
+	};
+	
+	class d_sub_kill_civ_points {
+			title = "$STR_DOM_MISSIONSTRING_1888";
+			values[] = {0,1,2,3,4,5,10,25,100};
+			default = 0;
+			texts[] = {"0","1","2","3","4","5","10","25","100"};
+	};
+
 #ifndef __TT__
 	class d_params_dl_9 {
 		title = "$STR_DOM_MISSIONSTRING_1575";

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -9072,6 +9072,51 @@
 <Original>Call Air Taxi</Original>
 <Russian>Вызов Эвакуации (такси)</Russian>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1885">
+<English>Disable artillery cooldown</English>
+<Spanish>Disable artillery cooldown</Spanish>
+<Portuguese>Disable artillery cooldown</Portuguese>
+<Korean>Disable artillery cooldown</Korean>
+<Japanese>Disable artillery cooldown</Japanese>
+<Original>Disable artillery cooldown</Original>
+<Russian>Disable artillery cooldown</Russian>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1888">
+<English>Subtract score when a player kills a civilian:</English>
+<Spanish>Subtract score when a player kills a civilian:</Spanish>
+<Portuguese>Subtract score when a player kills a civilian:</Portuguese>
+<Korean>Subtract score when a player kills a civilian:</Korean>
+<Japanese>Subtract score when a player kills a civilian:</Japanese>
+<Original>Subtract score when a player kills a civilian:</Original>
+<Russian>Subtract score when a player kills a civilian:</Russian>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1889">
+<English>%1 killed a civilian!  Penalty of %2 points deducted.</English>
+<Spanish>%1 killed a civilian!  Penalty of %2 points deducted.</Spanish>
+<Portuguese>%1 killed a civilian!  Penalty of %2 points deducted.</Portuguese>
+<Korean>%1 killed a civilian!  Penalty of %2 points deducted.</Korean>
+<Japanese>%1 killed a civilian!  Penalty of %2 points deducted.</Japanese>
+<Original>%1 killed a civilian!  Penalty of %2 points deducted.</Original>
+<Russian>%1 killed a civilian!  Penalty of %2 points deducted.</Russian>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1890">
+<English>Enable civilians</English>
+<Spanish>Enable civilians</Spanish>
+<Portuguese>Enable civilians</Portuguese>
+<Korean>Enable civilians</Korean>
+<Japanese>Enable civilians</Japanese>
+<Original>Enable civilians</Original>
+<Russian>Enable civilians</Russian>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1893">
+<English>Civilian unit count per target</English>
+<Spanish>Civilian unit count per target</Spanish>
+<Portuguese>Civilian unit count per target</Portuguese>
+<Korean>Civilian unit count per target</Korean>
+<Japanese>Civilian unit count per target</Japanese>
+<Original>Civilian unit count per target</Original>
+<Russian>Civilian unit count per target</Russian>
+</Key>
 </Container>
 </Package>
 </Project>

--- a/co30_Domination.Altis/x_bikb/domkba3.bikb
+++ b/co30_Domination.Altis/x_bikb/domkba3.bikb
@@ -322,6 +322,14 @@ class Sentences {
 			class 1 {type = "simple";};
 		};
 	};
+	class PenaltyKilledCivilian {
+		text = "$STR_DOM_MISSIONSTRING_1889";
+		speech[] = {};
+		class Arguments {
+			class 1 {type = "simple";};
+			class 2 {type = "simple";};
+		};
+	};
 };
 class Arguments{};
 class Special{};

--- a/co30_Domination.Altis/x_shc/x_f/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/x_shc/x_f/fn_createmaintarget.sqf
@@ -228,21 +228,13 @@ if (d_enable_civs == 1) then {
 			params ["_cVictim", "_cKiller"];
 			if (_cKiller call d_fnc_isplayer) then 
 			{
-				//hint formatText ["%1 killed a civilian!", name _cKiller];
-				private _topicside = d_kb_topic_side;
-				private _topicside = d_kb_topic_side;
-				private _logic = d_kb_logic2;
-				private _logic1 = d_kb_logic1;
-				private _channel = d_kbtel_chan;
 				d_hq_logic_blufor1 kbTell [
-					//_logic,
 					d_hq_logic_blufor2,
-					//_topicside,
 					"HQ_W",
 					"PenaltyKilledCivilian",
 					["1", "", name _cKiller, []],
 					["2", "", str d_sub_kill_civ_points, []],
-					 _channel
+					d_kbtel_chan
 				];
 	
 				//subtract penalty for killing a civilian

--- a/co30_Domination.Altis/x_shc/x_f/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/x_shc/x_f/fn_createmaintarget.sqf
@@ -164,6 +164,95 @@ if (!isServer) then {
 	[missionNamespace, ["d_mt_mobile_hq_down", false]] remoteExecCall ["setVariable", 2];
 };
 sleep 0.1;
+
+//create civilian module
+placeCivilianSpotsAndUnits = {
+	
+	//_randomPos = [[[_trg_center, 200]],[]] call BIS_fnc_randomPos;
+	
+	_ms1 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	_ms1 call civModuleSetVars;
+	__TRACE_1("_ms1");
+	
+	_ms2 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	_ms2 call civModuleSetVars;
+	__TRACE_1("_ms2");
+	
+	_ms3 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	_ms3 call civModuleSetVars;
+	__TRACE_1("_ms3");
+
+	_mu1 = _grp createUnit ["ModuleCivilianPresenceUnit_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	__TRACE_1("_mu1");
+	
+	_mu2 = _grp createUnit ["ModuleCivilianPresenceUnit_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	__TRACE_1("_mu2");
+	
+	_mu3 = _grp createUnit ["ModuleCivilianPresenceUnit_F", [[[_trg_center, 200]],[]] call BIS_fnc_randomPos, [], 0, "NONE"];
+	__TRACE_1("_mu3");
+	
+};
+
+civModuleSetVars = {
+	_this setVariable ["#capacity",5];
+	_this setVariable ["#usebuilding",true];
+	_this setVariable ["#terminal",false];
+	//_m1 setVariable ["#type",5];
+};
+
+if (d_enable_civs == 1) then {
+	_grp = createGroup civilian;
+	_target_name = d_target_names select d_current_target_index;
+	_marker_name = Format ["d_target_%1", d_current_target_index];
+	
+	__TRACE_1("_this");
+	__TRACE_1("d_current_target_index");
+	__TRACE_1("_target_name");
+	__TRACE_1("_marker_name");
+	
+	__TRACE_1("Placing a civilian module...");
+	_this call placeCivilianSpotsAndUnits;
+	
+	_m = _grp createUnit ["ModuleCivilianPresence_F", [0,0,0], [], 0, "NONE"];
+	
+	_m setVariable ["#debug",true]; // Debug mode on
+	 
+	_m setVariable ["#area",[_trg_center,1000,1000,0,true,-1]];  // Fixed! this gets passed to https://community.bistudio.com/wiki/inAreaArray 
+	_m setVariable ["#useagents",true];
+	_m setVariable ["#usepanicmode",false];
+	_m setVariable ["#unitcount",d_civ_unitcount];
+	//_m setVariable ["#onCreated", { hint "created a civilian!" }];
+	_m setVariable ["#onCreated", {
+		_this addMPEventHandler ["MPKilled", 
+		{
+			params ["_cVictim", "_cKiller"];
+			if (_cKiller call d_fnc_isplayer) then 
+			{
+				//hint formatText ["%1 killed a civilian!", name _cKiller];
+				private _topicside = d_kb_topic_side;
+				private _topicside = d_kb_topic_side;
+				private _logic = d_kb_logic2;
+				private _logic1 = d_kb_logic1;
+				private _channel = d_kbtel_chan;
+				d_hq_logic_blufor1 kbTell [
+					//_logic,
+					d_hq_logic_blufor2,
+					//_topicside,
+					"HQ_W",
+					"PenaltyKilledCivilian",
+					["1", "", name _cKiller, []],
+					["2", "", str d_sub_kill_civ_points, []],
+					 _channel
+				];
+	
+				//subtract penalty for killing a civilian
+				[player, d_sub_kill_civ_points * -1] remoteExecCall ["addScore", 2]
+			};
+		}];
+	}];
+	//_m setVariable ["#onDeleted", { hint "deleted a civilian!" }];
+ };
+//end create civilian module
 #endif
 
 #ifdef __DEBUG__


### PR DESCRIPTION
Added functionality to create civilian modules and configure properties related to civ handlers.  Killing a civilian can penalize the player (decrease player score) according to configuration.  Killing a civ is announced via side chat.

There is no cleanup for the spawned civ modules.  One civ module is spawned upon target init but is not yet cleaned up during target teardown.