### PR TITLE
snipers spawned in tall buildings, new garrison behaviors and parameters, new player target selection parameter

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -361,6 +361,13 @@ class Params {
 		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
 	};
 	
+	class d_with_targetselect_count {
+		title = "$STR_DOM_MISSIONSTRING_1953A";
+		values[] = {4,8,12,-1};
+		default = 4;
+		texts[] = {"4 targets","8 targets","12 targets","Entire map"};
+	};
+	
 	class d_MissionType {
 		title = "$STR_DOM_MISSIONSTRING_1052";
 		values[] = {0,1,2};
@@ -816,12 +823,26 @@ class Params {
 		default = 1;
 		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
 	};
-
-	class d_enemy_occupy_bldgs_troop_level {
-		title = "$STR_DOM_MISSIONSTRING_1900";
-		values[] = {0, 1, 2, 3, 4};
+	
+	class d_enemy_garrison_troop_occupy_count {
+		title = "$STR_DOM_MISSIONSTRING_1900A";
+		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30};
 		default = 0;
-		texts[] = {"0 - Low (4 groups)", "1 - Medium (8 groups)", "2 - High (16 groups)", "3 - Very High (24 groups)", "4 - Insane (32 groups)"};
+		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"};
+	};
+	
+	class d_enemy_garrison_troop_ambush_count {
+		title = "$STR_DOM_MISSIONSTRING_1900B";
+		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30};
+		default = 3;
+		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"};
+	};
+	
+	class d_enemy_garrison_troop_sniper_count {
+		title = "$STR_DOM_MISSIONSTRING_1900C";
+		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 45, 60};
+		default = 8;
+		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30", "45", "60"};
 	};
 
 	class d_enemy_max_barracks_count {

--- a/co30_Domination.Altis/server/fn_selectnexttarget.sqf
+++ b/co30_Domination.Altis/server/fn_selectnexttarget.sqf
@@ -9,6 +9,13 @@ if (count d_mttargets_ar > 1) then {
 	d_next_sels_ar = [];
 	
 	private _howmany = 4;
+	
+	if (d_with_targetselect_count == -1) then {
+		_howmany = 999;
+	} else {
+		_howmany = d_with_targetselect_count;
+	};
+		
 	if (count d_mttargets_ar < 4) then {
 		_howmany = count d_mttargets_ar;
 	};

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -9973,15 +9973,35 @@
 <Russian>Максимальное число казарм пехотинцев противника</Russian>
 <Chinesesimp>敌人步兵营的最大数量</Chinesesimp>
 </Key>
-<Key ID="STR_DOM_MISSIONSTRING_1900">
-<English>Occupy buildings troop level</English>
-<Spanish>Occupy buildings troop level</Spanish>
-<Portuguese>Occupy buildings troop level</Portuguese>
-<Korean>Occupy buildings troop level</Korean>
-<Japanese>Occupy buildings troop level</Japanese>
-<Original>Occupy buildings troop level</Original>
-<Russian>Уровень занятия домов противником</Russian>
-<Chinesesimp>占据建筑物部队的等级</Chinesesimp>
+<Key ID="STR_DOM_MISSIONSTRING_1900A">
+<English>Garrisoned infantry group count - occupy mode</English>
+<Spanish>Garrisoned infantry group count - occupy mode</Spanish>
+<Portuguese>Garrisoned infantry group count - occupy mode</Portuguese>
+<Korean>Garrisoned infantry group count - occupy mode</Korean>
+<Japanese>Garrisoned infantry group count - occupy mode</Japanese>
+<Original>Garrisoned infantry group count - occupy mode</Original>
+<Russian>Garrisoned infantry group count - occupy mode</Russian>
+<Chinesesimp>Garrisoned infantry group count - occupy mode</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1900B">
+<English>Garrisoned infantry group count - ambush mode</English>
+<Spanish>Garrisoned infantry group count - ambush mode</Spanish>
+<Portuguese>Garrisoned infantry group count - ambush mode</Portuguese>
+<Korean>Garrisoned infantry group count - ambush mode</Korean>
+<Japanese>Garrisoned infantry group count - ambush mode</Japanese>
+<Original>Garrisoned infantry group count - ambush mode</Original>
+<Russian>Garrisoned infantry group count - ambush mode</Russian>
+<Chinesesimp>Garrisoned infantry group count - ambush mode</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1900C">
+<English>Garrisoned infantry group count - sniper mode</English>
+<Spanish>Garrisoned infantry group count - sniper mode</Spanish>
+<Portuguese>Garrisoned infantry group count - sniper mode</Portuguese>
+<Korean>Garrisoned infantry group count - sniper mode</Korean>
+<Japanese>Garrisoned infantry group count - sniper mode</Japanese>
+<Original>Garrisoned infantry group count - sniper mode</Original>
+<Russian>Garrisoned infantry group count - sniper mode</Russian>
+<Chinesesimp>Garrisoned infantry group count - sniper mode</Chinesesimp>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1920">
 <English>Civilian group count per target</English>
@@ -10232,6 +10252,16 @@
 <Original>Players can select next main target:</Original>
 <Russian>Игроки могут выбрать следующую основную цель:</Russian>
 <Chinesesimp>玩家可以选择下一个主要目标:</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1953A">
+<English>Players can select from available targets:</English>
+<Spanish>Players can select from available targets:</Spanish>
+<Portuguese>Players can select from available targets:</Portuguese>
+<Korean>Players can select from available targets:</Korean>
+<Japanese>Players can select from available targets:</Japanese>
+<Original>Players can select from available targets:</Original>
+<Russian>Players can select from available targets:</Russian>
+<Chinesesimp>Players can select from available targets:</Chinesesimp>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1954">
 <English>Main target selection time left</English>


### PR DESCRIPTION
added: three modes of garrisoned troop behavior, snipers are placed in tallest buildings first
added: parameter to allow players more target selections across the map, discrete parameters for each of the three garrison behaviors
fixed: removed occupy buildings troop level parameter, replaced with three parameters for garrison behaviors

The new parameters are set to have low default values for minimal impact on the default mission (ie-- a low count of the new garrison groups are spawned) but parameters can be selected for many extra enemies if desired.

occupy groups - large group, AI are immediately permitted to move
ambush groups - medium group, AI are able to move if firedNear is triggered (shots within 69m)
sniper groups - small group, AI are stationary forever, spawned in tall buildings