### PR TITLE
added: increased range of possible sniper spawn positions to allow fo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+*.iml
+*.ipr
 /co30_Domination4.Altis/*
 /co30_Domination.Malden/*
 /co30_Domination.Sara/*

--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -299,6 +299,7 @@ class cfgFunctions {
 			addc(HousePatrol);
 			addc(Zen_OccupyHouse);
 			addc(Zen_JBOY_UpDown);
+			addc(hallyg_dlegion_Snipe);
 			addc(ambientradiochatter);
 		};
 		class Dom_KBTell {

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -835,16 +835,37 @@ class Params {
 	class d_enemy_garrison_troop_ambush_count {
 		title = "$STR_DOM_MISSIONSTRING_1900B";
 		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30};
-		default = 3;
+		default = 0;
 		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"};
 	};
 	
 	class d_enemy_garrison_troop_sniper_count {
 		title = "$STR_DOM_MISSIONSTRING_1900C";
-		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 45, 60};
-		default = 8;
-		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30", "45", "60"};
+		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 45};
+		default = 0;
+		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30", "45", "60", "75", "90"};
 	};
+	
+	class d_enemy_garrison_troop_sniper_awareness {
+		title = "$STR_DOM_MISSIONSTRING_1900D";
+		values[] = {0,1};
+		default = 1;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+	};
+	
+	class d_enemy_garrison_troop_sniper_general_skill {
+        title = "$STR_DOM_MISSIONSTRING_1900E";
+        values[] = {-1, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1};
+        default = -1;
+        texts[] = {"default (recommended)", "0.1", "0.2", "0.3", "0.4 (low)", "0.5", "0.6 (medium)", "0.7", "0.8 (hard)", "0.9", "1.0 (insane)"};
+    };
+
+    class d_enemy_garrison_troop_sniper_aimingShake_skill {
+        title = "$STR_DOM_MISSIONSTRING_1900F";
+        values[] = {-1, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1};
+        default = -1;
+        texts[] = {"default (recommended)", "0.1", "0.2", "0.3", "0.4 (low)", "0.5", "0.6 (medium)", "0.7", "0.8 (hard)", "0.9", "1.0 (insane)"};
+    };
 
 	class d_enemy_max_barracks_count {
 		title = "$STR_DOM_MISSIONSTRING_1899";
@@ -855,9 +876,9 @@ class Params {
 	
 	class d_enemy_max_camps_count {
 		title = "$STR_DOM_MISSIONSTRING_1930";
-		values[] = {1, 2, 3, 4, 5, -1};
+		values[] = {1, 2, 3, 4, -1};
 		default = -1;
-		texts[] = {"1", "2", "3", "4", "5", "Random"};
+		texts[] = {"1", "2", "3", "4", "5"};
 	};
 	
 	class d_first_enemy_camp_near_target_center {

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -822,6 +822,9 @@ if (!d_tt_tanoa) then {
 #include "d_specops_O_default.sqf"
 #endif
 	];
+	
+	d_sniper_E = [["East","OPF_F","Infantry","OI_SniperTeam"] call d_fnc_GetConfigGroup];
+
 	d_specops_W = call {
 		if (d_rhs) exitWith {
 			[["West","rhs_faction_socom_marsoc","rhs_group_nato_marsoc_infantry","rhs_group_nato_marsoc_infantry_squad"] call d_fnc_GetConfigGroup, ["West","rhs_faction_socom_marsoc","rhs_group_nato_marsoc_infantry","rhs_group_nato_marsoc_infantry_team"] call d_fnc_GetConfigGroup]
@@ -831,6 +834,9 @@ if (!d_tt_tanoa) then {
 		};
 		[["West","BLU_F","Infantry","BUS_ReconTeam"] call d_fnc_GetConfigGroup]
 	};
+	
+	d_sniper_W = [["West","BLU_F","Infantry","BUS_SniperTeam"] call d_fnc_GetConfigGroup];
+	
 #ifdef __RHS__
 	d_specops_E = [
 		["East","rhs_faction_vmf","rhs_group_rus_vmf_infantry_recon","rhs_group_rus_vmf_infantry_recon_squad"] call d_fnc_GetConfigGroup, ["East","rhs_faction_vmf","rhs_group_rus_vmf_infantry_recon","rhs_group_rus_vmf_infantry_recon_squad_2mg"] call d_fnc_GetConfigGroup,

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe.sqf
@@ -1,0 +1,137 @@
+#define __DEBUG__
+#define THIS_FILE "fn_hallyg_dlegion_Snipe.sqf"
+#include "..\x_setup.sqf"
+
+#define EYE_HEIGHT 1.53
+
+params ["_unit", "_targetSide"];
+
+//by HallyG, dlegion
+private _isLOS = {
+	params ["_looker", "_target", "_FOV"];
+    
+    if ([position _looker, getDir _looker, _FOV, position _target] call BIS_fnc_inAngleSector) then {
+    	_lineIntersections = lineIntersectsSurfaces [(AGLtoASL (_looker modelToWorldVisual (_looker selectionPosition "pilot"))), getPosASL _target, _target, _looker, true, 1,"GEOM","NONE"];
+    	if (count (_lineIntersections) > 0) exitWith {
+    		false
+		};
+    	true
+    } else {
+    	false
+    };
+};
+
+//by Jezuro
+private _sortArrayByDistance = {
+    params ["_unitArray", "_fromPosition"];
+    _unsorted = _unitArray;
+    _sorted = [];
+    _pos = _fromPosition;
+
+    {
+        _closest = _unsorted select 0;
+        {if ((getPos _x distance _pos) < (getPos _closest distance _pos)) then {_closest = _x}} forEach _unsorted;
+        _sorted = _sorted + [_closest];
+        _unsorted = _unsorted - [_closest]
+    } forEach _unsorted;
+
+    _sorted
+};
+
+//by sarogahtyp
+private _isVisible = {
+    params ["_unit", "_target"];
+    _visibleThreshold = 0.015;
+    _targetEye = eyepos _target;
+    _unitEye = eyepos _unit;
+
+    //vector origins are half meter away from looker and target (uses 0.5 of a normalized vector which by definition is 1 meter)
+    _unit_in_dir = _unitEye vectorAdd ((_unitEye vectorFromTo _targetEye) vectorMultiply 0.5);
+    _target_in_dir = _targetEye vectorAdd ((_targetEye vectorFromTo _unitEye) vectorMultiply 0.5);
+
+    _visiblity = parseNumber str ([objNull, "VIEW"] checkVisibility [_target_in_dir, _unit_in_dir]);
+
+    if (_visiblity > _visibleThreshold) then {
+        true
+    } else {
+        false
+    };
+};
+
+//in meters
+_detectionRadius = 2000;
+
+sleep random 1;
+
+_unit disableAI "PATH";
+_unit disableAI "AIMINGERROR";
+_unit disableAI "TARGET";
+_unit forceSpeed 0;
+private _lastFired = 0;
+_unit setUnitPos "UP";
+
+//sniper aware loop
+while { 1 == 1 } do {
+	
+	sleep 1;
+	
+    _Dtargets = [];
+
+    {
+        if (
+            (_x distance2D _unit) < _detectionRadius && (side _x == _targetSide) && (_x isKindOf "CAManBase")
+            && (alive _x) && !(vehicle _unit isKindOf "Air")
+        ) then {
+            _unit reveal [_x,4];
+            _Dtargets pushBack _x;
+        };
+    } forEach allunits;
+    
+    _fired = false;
+    _targetUnit = [];
+    {
+        if (([_unit, _x] call _isVisible) || ([_unit, _x, 360] call _isLOS)) then {
+        	//to check if unit actually fired
+        	_ammoCount = _unit ammo primaryWeapon _unit;
+			_targetUnit = _x;
+            _unit doTarget _x;
+            _unit doSuppressiveFire _x;
+			//_unit forceWeaponFire [(currentWeapon _unit), "Single"];
+			sleep 7;
+			if (_ammoCount > _unit ammo primaryWeapon _unit) then {
+				//yes the unit actually fired
+				_fired = true;
+				_lastFired = time;
+			};
+			exit;
+        } else {
+        };
+    } forEach ([_Dtargets, getPos _unit] call _sortArrayByDistance);
+
+	sleep 1;
+
+	if (_fired) then {
+	    _unit setVehicleAmmo 1;
+	} else {
+		//if (count _Dtargets == 0 || _lastFired + 10 > time) then {
+			switch (toUpper (unitPos _unit)) do {
+				case "AUTO";
+				case "UP": {
+					//if standing upright and could not fire on a target then lay down for a while
+					_unit setUnitPos "DOWN";
+					sleep ((ceil random 40) max 7);
+				};
+				case "DOWN": {
+					//if down and could not fire on a target then rise to middle position
+					_unit setUnitPos "MIDDLE";
+					sleep 3;
+				};
+				case "MIDDLE": {
+					//if middle and could not fire on a target then rise to up position
+					_unit setUnitPos "UP";	
+					sleep 3;
+				};
+			};
+		//};
+	};
+};

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10003,6 +10003,36 @@
 <Russian>Garrisoned infantry group count - sniper mode</Russian>
 <Chinesesimp>Garrisoned infantry group count - sniper mode</Chinesesimp>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1900D">
+<English>Garrisoned infantry sniper mode - advanced awareness</English>
+<Spanish>Garrisoned infantry sniper mode - advanced awareness</Spanish>
+<Portuguese>Garrisoned infantry sniper mode - advanced awareness</Portuguese>
+<Korean>Garrisoned infantry sniper mode - advanced awareness</Korean>
+<Japanese>Garrisoned infantry sniper mode - advanced awareness</Japanese>
+<Original>Garrisoned infantry sniper mode - advanced awareness</Original>
+<Russian>Garrisoned infantry sniper mode - advanced awareness</Russian>
+<Chinesesimp>Garrisoned infantry sniper mode - advanced awareness</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1900E">
+<English>Garrisoned infantry sniper mode - general skill</English>
+<Spanish>Garrisoned infantry sniper mode - general skill</Spanish>
+<Portuguese>Garrisoned infantry sniper mode - general skill</Portuguese>
+<Korean>Garrisoned infantry sniper mode - general skill</Korean>
+<Japanese>Garrisoned infantry sniper mode - general skill</Japanese>
+<Original>Garrisoned infantry sniper mode - general skill</Original>
+<Russian>Garrisoned infantry sniper mode - general skill</Russian>
+<Chinesesimp>Garrisoned infantry sniper mode - general skill</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1900F">
+<English>Garrisoned infantry sniper mode - aimingShake skill</English>
+<Spanish>Garrisoned infantry sniper mode - aimingShake skill</Spanish>
+<Portuguese>Garrisoned infantry sniper mode - aimingShake skill</Portuguese>
+<Korean>Garrisoned infantry sniper mode - aimingShake skill</Korean>
+<Japanese>Garrisoned infantry sniper mode - aimingShake skill</Japanese>
+<Original>Garrisoned infantry sniper mode - aimingShake skill</Original>
+<Russian>Garrisoned infantry sniper mode - aimingShake skill</Russian>
+<Chinesesimp>Garrisoned infantry sniper mode - aimingShake skill</Chinesesimp>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1920">
 <English>Civilian group count per target</English>
 <Spanish>Civilian group count per target</Spanish>
@@ -10392,16 +10422,6 @@
 <Original>Auto Viewdistance change at main targets disabled!</Original>
 <Russian>Автоматическое изменение видимости на основных задачах отключено!</Russian>
 <Chinesesimp>Auto Viewdistance change at main targets disabled!</Chinesesimp>
-</Key>
-<Key ID="STR_DOM_MISSIONSTRING_1967">
-<English>Stall</English>
-<Spanish>Stall</Spanish>
-<Portuguese>Stall</Portuguese>
-<Korean>Stall</Korean>
-<Japanese>Stall</Japanese>
-<Original>Stall</Original>
-<Russian>Stall</Russian>
-<Chinesesimp>Stall</Chinesesimp>
 </Key>
 </Container>
 </Package>


### PR DESCRIPTION
…r better shooting on the main target (425m radius)

added: sniper down posture sleeps for a random period of time to keep cover when no targets are found
added: snipers now change posture to obtain line of sight
added: snipers now have spotters (2 units in sniper group)
added: sniper parameters for skill (general and aimingShake) and awareness (default behavior or with sniper script awareness)
added: sniper groups can now engage at distances of more than 400m using script by HallyG and dlegion
added: SniperTeam added to Opfor and Blufor
added: sniper positions in buildings now sorted by highest elevation on Z axis (no longer sorted by building height)
added: sniper target check using checkVisibility using script by sarogahtyp
added: sniper now chooses nearest target using script by Jezuro