### PR TITLE
DO NOT MERGE DO NOT MERGE - for discussion, rough concept for spawnin…

### DIFF
--- a/co30_Domination.Altis/missions/fn_getsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_getsidemission.sqf
@@ -28,8 +28,42 @@ if (d_MissionType != 2) then {
 };
 #endif
 
-private _cur_sm_idx = d_side_missions_random # d_current_mission_counter;
-d_current_mission_counter = d_current_mission_counter + 1;
+private _cur_sm_idx = nil;
+private _smpos = [[0, 0, 0]];
+private _smkey = "";
+private _iter = 0;
+
+if (d_MissionType == 0) then {	
+	
+	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smpos # 0: %1", _smpos # 0]];
+	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smkey: %1", _smkey]];
+	
+	
+	while {true} do {
+		diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo2 too far: %1 %2", _smkey, _smpos]];	
+		_iter = _iter + 1;
+		
+		_cur_sm_idx = d_side_missions_random # _iter;
+		_smkey = "d_sm_" + str _cur_sm_idx;
+		_smpos = _smkey call d_fnc_smmapos;
+		
+		//select sidemission if within max distance from main target and not previously selected
+		if ((d_cur_tgt_pos distance2D (_smpos # 0) < d_sm_max_distance_from_mt) && (d_sm_selected findIf { _x == _smkey } == -1)) exitWith {
+			//add to selected array
+			d_sm_selected pushBack _smkey;
+		};
+		
+		if (_iter == d_number_side_missions) then {
+			//failed to find a sidemission near the main target, try again later
+			sleep 180;
+			_iter = 0;
+		};
+		
+	};
+} else {
+	_cur_sm_idx = d_side_missions_random # d_current_mission_counter;
+	d_current_mission_counter = d_current_mission_counter + 1;
+};
 
 __TRACE_1("","_cur_sm_idx")
 

--- a/co30_Domination.Altis/server/fn_setupserver.sqf
+++ b/co30_Domination.Altis/server/fn_setupserver.sqf
@@ -6,6 +6,9 @@ if (!isServer) exitWith {};
 
 d_last_bonus_vec = "";
 
+d_sm_selected = [];
+d_sm_max_distance_from_mt = 1500;
+
 d_sm_triggervb = [
 	[0, 0, 0],
 	[0, 0, 0, false, 0],
@@ -25,7 +28,8 @@ if (d_MissionType in [0,2]) then {
 		sleep 20;
 		if (d_MissionType != 2) then {
 			private _num_p = call d_fnc_PlayersNumber;
-			private _waittime = 200 + random 10;
+			//private _waittime = 200 + random 10;
+			private _waittime = 60 + random 10;
 			if (_num_p > 0) then {
 				private _fidx = d_time_until_next_sidemission findIf {_num_p <= _x # 0};
 				if (_fidx > -1) then {


### PR DESCRIPTION
…g sidemissions only located near the current maintarget

This is ugly code to only select sidemissions that are within 1500m of the current maintarget marker.  This is just junk code for discussion and should not be merged.

The concept for this change is to keep the players closer together on the map.  For servers with a low player count, having the sidemission randomly spawn in a location far away can split the team.  This code just ensures the next sidemission is close to the maintarget by creating an array of sidemissions "d_sm_selected".  The script sleeps until the next sidemission is ready to begin.  There are usually 3-5 sidemissions within 1500m of most maintarget markers.

One improvement would be to require the players to clear all nearby sidemissions (in "d_sm_selected") before the maintarget is complete.  That code isn't included in this proof of concept but where could that be added?  in fn_createnexttarget.sqf to the _tsar strings?

As far as implementation, I was considering adding another value d_MissionType == 3 to represent this mode, something like "Main target and nearby sidemissions" as a new STR_DOM_MISSIONSTRING.

Xeno, what do you think?  I am very happy to implement whatever you suggest here or let you take it over or just abandon it if there are problems.