### PR TITLE
added: parameters for enemy spawn radius

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -833,6 +833,13 @@ class Params {
 		default = 2;
 		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"};
 	};
+	
+	class d_occ_rad {
+		title = "$STR_DOM_MISSIONSTRING_1901A";
+		values[] = {250, 425, 650, 900, 1250};
+		default = 250;
+		texts[] = {"250m", "425m", "650m", "900m", "1250m"};
+	};
 
 	class d_enemy_garrison_troop_ambush_count {
 		title = "$STR_DOM_MISSIONSTRING_1900B";
@@ -840,12 +847,26 @@ class Params {
 		default = 1;
 		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"};
 	};
+	
+	class d_amb_rad {
+		title = "$STR_DOM_MISSIONSTRING_1901B";
+		values[] = {250, 425, 650, 900, 1250};
+		default = 250;
+		texts[] = {"250m", "425m", "650m", "900m", "1250m"};
+	};
 
 	class d_enemy_garrison_troop_sniper_count {
 		title = "$STR_DOM_MISSIONSTRING_1900C";
 		values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 45};
 		default = 2;
 		texts[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30", "45", "60", "75", "90"};
+	};
+	
+	class d_snp_rad {
+		title = "$STR_DOM_MISSIONSTRING_1901C";
+		values[] = {250, 425, 650, 900, 1250};
+		default = 425;
+		texts[] = {"250m", "425m", "650m", "900m", "1250m"};
 	};
 
 	class d_enemy_garrison_troop_sniper_awareness {
@@ -889,7 +910,7 @@ class Params {
 		default = 0;
 		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
 	};
-
+	
 	class d_WithAmbientRadio {
 		title = "$STR_DOM_MISSIONSTRING_1948";
 		values[] = {0,1};

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -357,7 +357,7 @@ if (d_enemy_occupy_bldgs == 1) then {
 			[
 				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
 				selectRandom [2, 3, 4],			//unit count
-				250,		//fillRadius
+				d_occ_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
 				false,		//fillTopDown
@@ -373,7 +373,7 @@ if (d_enemy_occupy_bldgs == 1) then {
 			[
 				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
 				selectRandom [3, 4],		//unit count
-				250,		//fillRadius
+				d_amb_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
 				false,		//fillTopDown
@@ -389,7 +389,7 @@ if (d_enemy_occupy_bldgs == 1) then {
 	//START create garrisoned groups of snipers
 	//prepare to create garrisoned groups of snipers - find and sort buildings
 	private _buildingsArray = [];
-	private _buildingsArrayRaw = nearestObjects [_trg_center, ["Building", "House"], 425];
+	private _buildingsArrayRaw = nearestObjects [_trg_center, ["Building", "House"], d_snp_rad];
 
 	if (_buildingsArrayRaw isEqualTo []) exitWith {};
 

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10063,6 +10063,36 @@
 <Russian>Расположить первый бункер противника ближе к центру города</Russian>
 <Chinesesimp>找到第一个在主要目标中心附近捕获的敌人营地</Chinesesimp>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1901A">
+<English>Enemy placement target fill radius - occupy infantry</English>
+<Spanish>Enemy placement target fill radius - occupy infantry</Spanish>
+<Portuguese>Enemy placement target fill radius - occupy infantry</Portuguese>
+<Korean>Enemy placement target fill radius - occupy infantry</Korean>
+<Japanese>Enemy placement target fill radius - occupy infantry</Japanese>
+<Original>Enemy placement target fill radius - occupy infantry</Original>
+<Russian>Enemy placement target fill radius - occupy infantry</Russian>
+<Chinesesimp>Enemy placement target fill radius - occupy infantry</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1901B">
+<English>Enemy placement target fill radius - ambush infantry</English>
+<Spanish>Enemy placement target fill radius - ambush infantry</Spanish>
+<Portuguese>Enemy placement target fill radius - ambush infantry</Portuguese>
+<Korean>Enemy placement target fill radius - ambush infantry</Korean>
+<Japanese>Enemy placement target fill radius - ambush infantry</Japanese>
+<Original>Enemy placement target fill radius - ambush infantry</Original>
+<Russian>Enemy placement target fill radius - ambush infantry</Russian>
+<Chinesesimp>Enemy placement target fill radius - ambush infantry</Chinesesimp>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1901C">
+<English>Enemy placement target fill radius - sniper infantry</English>
+<Spanish>Enemy placement target fill radius - sniper infantry</Spanish>
+<Portuguese>Enemy placement target fill radius - sniper infantry</Portuguese>
+<Korean>Enemy placement target fill radius - sniper infantry</Korean>
+<Japanese>Enemy placement target fill radius - sniper infantry</Japanese>
+<Original>Enemy placement target fill radius - sniper infantry</Original>
+<Russian>Enemy placement target fill radius - sniper infantry</Russian>
+<Chinesesimp>Enemy placement target fill radius - sniper infantry</Chinesesimp>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1932">
 <English>Destination:</English>
 <Spanish>Destination:</Spanish>


### PR DESCRIPTION
Submitting again with my proper Github login.

Parameterized radius, can create enemy units with a chosen placement radius. Ambush groups that are outside the main target can act as quick reaction to fighting in town. Creates some interesting fights and sniper angles. Defaults are not changed; this pull request does not change the default experience.