### PR TITLE
fixed: d_max_camp_cnt logic and parameter fix

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -930,17 +930,10 @@ class Params {
 
 	class d_max_camp_cnt {
 		title = "$STR_DOM_MISSIONSTRING_1930";
-		values[] = {1, 2, 3, 4, -1};
+		values[] = {1, 2, 3, 4, 5, -1};
 		default = -1;
-		texts[] = {"1", "2", "3", "4", "5"};
+		texts[] = {"1", "2", "3", "4", "5", "3 to 5"};
 	};
-	
-	class d_max_camp_cnt_method {
-    		title = "$STR_DOM_MISSIONSTRING_1930A";
-    		values[] = {0, 1};
-    		default = 0;
-    		texts[] = {"Random", "Maximum"};
-    	};
 
 	class d_camp_center {
 		title = "$STR_DOM_MISSIONSTRING_1931";

--- a/co30_Domination.Altis/init/initcommon.sqf
+++ b/co30_Domination.Altis/init/initcommon.sqf
@@ -96,7 +96,7 @@ if (isServer) then {
 #endif
 			];
 
-			// allmost the same like above
+			// almost the same like above
 			// first element the max number of ai "foot" groups that will get spawned, second element minimum number (no number for vehicles in group necessary)
 			d_footunits_guard = [
 #ifndef __TT__
@@ -154,7 +154,7 @@ if (isServer) then {
 				[[1,1], 1] // jeep with gl
 			];
 
-			// allmost the same like above
+			// almost the same like above
 			// first element the max number of ai "foot" groups that will get spawned, second element minimum number (no number for vehicles in group necessary)
 			d_footunits_guard = [
 				[2,1], // basic groups
@@ -202,7 +202,7 @@ if (isServer) then {
 				[[2,1], 1] // jeep with gl
 			];
 
-			// allmost the same like above
+			// almost the same like above
 			// first element the max number of ai "foot" groups that will get spawned, second element minimum number (no number for vehicles in group necessary)
 			d_footunits_guard = [
 				[3,1], // basic groups

--- a/co30_Domination.Altis/server/fn_createsecondary.sqf
+++ b/co30_Domination.Altis/server/fn_createsecondary.sqf
@@ -69,18 +69,10 @@ d_f_check_trigger = ([d_cur_tgt_pos, [d_cur_target_radius + 300, d_cur_target_ra
 sleep 1.234;
 #ifndef __TT__
 private "_nrcamps";
-if (d_max_camp_cnt_method == 1 && d_max_camp_cnt > 0) then {
+if (d_max_camp_cnt > 0) then {
 	_nrcamps = d_max_camp_cnt
 } else {
-	if (d_max_camp_cnt != -1 ) then {
-		//max camps is set, overwrite the random value
-		_nrcamps = ceil random d_max_camp_cnt;
-		if (_nrcamps == 0) then {
-			_nrcamps = 1;
-		};
-	} else {
-		_nrcamps = (ceil random 5) max 3;
-	};
+	_nrcamps = (ceil random 5) max 3;
 };
 #else
 private _nrcamps = (ceil random 6) max 4;

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -1274,12 +1274,12 @@
 <French>C'est un hélicoptère de levage normal.</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_187">
-<English>It can lift allmost any vehicle except wrecks.</English>
+<English>It can lift almost any vehicle except wrecks.</English>
 <Spanish>Puede levantar cualquier vehículo excepto chatarra.</Spanish>
-<Portuguese>Possa elevador allmost qualquer veículo excepto chatarra.</Portuguese>
+<Portuguese>Possa elevador almost qualquer veículo excepto chatarra.</Portuguese>
 <Korean>잔해를 제외한 거의 모든 장비을 수송할 수 있습니다.</Korean>
 <Japanese>残骸以外のほぼすべての車両を空輸できます。</Japanese>
-<Original>It can lift allmost any vehicle except wrecks.</Original>
+<Original>It can lift almost any vehicle except wrecks.</Original>
 <Russian>Цепляет технику, кроме уничтоженной (врек)!</Russian>
 <Chinesesimp>本机基本可以吊运全部载具，残骸除外.</Chinesesimp>
 <Chinese>本機基本可以吊運全部載具，殘骸除外‧</Chinese>
@@ -4021,12 +4021,12 @@
 <French>L'hélico de transport part maintenant!!!</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_640">
-<English>Air taxi allmost there, hang on...</English>
+<English>Air taxi almost there, hang on...</English>
 <Spanish>Taxi aéreo a punto de llegar, esté atento...</Spanish>
-<Portuguese>Táxi de ar allmost ali, pendura em cima...</Portuguese>
+<Portuguese>Táxi de ar almost ali, pendura em cima...</Portuguese>
 <Korean>후송헬기 거의 도착했으며, 현 위치에서 대기하십시오.</Korean>
 <Japanese>搬送ヘリコプターはすぐそこです、待機してください...</Japanese>
-<Original>Air taxi allmost there, hang on...</Original>
+<Original>Air taxi almost there, hang on...</Original>
 <Russian>Транспорт эвакуации почти прибыл, держитесь...</Russian>
 <Chinesesimp>空中运输就快到了,坚持住...</Chinesesimp>
 <Chinese>空中運輸就快到了,堅持住...</Chinese>
@@ -4069,12 +4069,12 @@
 <French>Le largage aérien est en route... ça va prendre du temps.</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_644">
-<English>Air drop allmost there, stand by!!!</English>
+<English>Air drop almost there, stand by!!!</English>
 <Spanish>El avión de suministros está llegando, espere.</Spanish>
-<Portuguese>Gota de ar allmost ali, posição por!!!</Portuguese>
+<Portuguese>Gota de ar almost ali, posição por!!!</Portuguese>
 <Korean>현재 투하위치에 거의 도착하였으며, 현 위치 고수할 것.</Korean>
 <Japanese>空中投下機が近づいています、スタンバイ!!!</Japanese>
-<Original>Air drop allmost there, stand by!!!</Original>
+<Original>Air drop almost there, stand by!!!</Original>
 <Russian>Поддержка с воздуха на подходе, ждите!!!</Russian>
 <Chinesesimp>空投即将到达，请准备好!!!</Chinesesimp>
 <Chinese>空投即將到達，請準備好!!!</Chinese>
@@ -8541,12 +8541,12 @@
 <French>%1 exécuté %2 frappes, salves %3</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1360">
-<English>%1 artillery observers spotted at main target. Be carefull...</English>
+<English>%1 artillery observers spotted at main target. Be careful...</English>
 <Spanish>%1 observadores de artillería vistos en el objetivo principal. Tenga cuidado...</Spanish>
-<Portuguese>%1 observadores de artilharia spotted em objetivo principal. Ser carefull...</Portuguese>
+<Portuguese>%1 observadores de artilharia spotted em objetivo principal. Ser careful...</Portuguese>
 <Korean>작전지역내에 %1명의 포병 감적수가 확인되었습니다.</Korean>
 <Japanese>メインターゲットで%1人の砲兵観測手を目撃。注意せよ...</Japanese>
-<Original>%1 artillery observers spotted at main target. Be carefull...</Original>
+<Original>%1 artillery observers spotted at main target. Be careful...</Original>
 <Russian>В городе есть %1 артнаводчика. Будьте осторожны...</Russian>
 <Chinesesimp>%1 个炮兵观察手在主目标被发现了,小心...</Chinesesimp>
 <Chinese>％1個砲兵觀察手在主目標被發現了，小心...</Chinese>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -12023,17 +12023,6 @@
 <Chinese>要佔領的最大敵人營地(camps)數量</Chinese>
 <French>Nombre maximum de camps ennemis à capturer</French>
 </Key>
-<Key ID="STR_DOM_MISSIONSTRING_1930A">
-<English>Maximum number of enemy camps to capture - random/maximum</English>
-<Spanish>Maximum number of enemy camps to capture - random/maximum</Spanish>
-<Portuguese>Maximum number of enemy camps to capture - random/maximum</Portuguese>
-<Korean>Maximum number of enemy camps to capture - random/maximum</Korean>
-<Japanese>Maximum number of enemy camps to capture - random/maximum</Japanese>
-<Original>Maximum number of enemy camps to capture - random/maximum</Original>
-<Russian>Максимальное количество бункеров противника для захвата - random/maximum</Russian>
-<Chinesesimp>捕获的敌方阵营的最大数量 - random/maximum</Chinesesimp>
-<Chinese>要佔領的最大敵人營地(camps)數量 - random/maximum</Chinese>
-</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1931">
 <English>Locate the first enemy camp to capture near the center of the main target</English>
 <Spanish>Locate the first enemy camp to capture near the center of the main target</Spanish>


### PR DESCRIPTION
This fixes a small bug in the number of created camps where 5 was ambiguous (either 5 or -1).

I also decided to remove the new "random/maximum" parameter since this is simpler.  The default behavior has not changed (creates 3 to 5 camps by default).