### PR TITLE
civilian unit types, faces, and vehicles now determined by which map is being played, other minor fixes

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -818,9 +818,9 @@ class Params {
 	
 	class d_enable_civ_vehs {
 		title = "$STR_DOM_MISSIONSTRING_1890CIVVEH";
-		values[] = {0, 25, 50, 75, 100};
+		values[] = {0, 10, 25, 50, 75, 100};
 		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_363","Low","Medium","High","Maximum"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_363", "Very Low", "Low","Medium","High","Maximum"};
 	};
 	
 	class d_enable_civ_vehs_rad {
@@ -867,9 +867,9 @@ class Params {
 
 	class d_ai_awareness_rad {
 		title = "$STR_DOM_MISSIONSTRING_1900AWARE";
-		values[] = {-1, 10, 25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 400, 500, 750, 1000};
+		values[] = {-1, 10, 25, 50, 75, 100, 150, 200, 250, 300, 400, 450, 500, 550, 600, 650, 700, 800, 900, 1000};
 		default = -1;
-		texts[] = {"$STR_DOM_MISSIONSTRING_1007", "10m", "25m", "50m", "75m", "100m", "125m", "150m", "175m", "200m", "225m", "250m", "275m", "300m", "400m", "500m (recommended)", "750m", "1000m"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007", "10m", "25m", "50m", "75m", "100m", "150m", "200m", "250m", "300m", "400m", "450m", "500m", "550m", "600m", "650m (recommended)", "700m", "800m", "900m", "1000m"};
 	};
 	
 	class d_snp_aware {

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -1872,6 +1872,9 @@ d_base_apc_vec =
 #ifdef __CUP_TAKISTAN__
 		_civVehiclesWeightedRuralCupRemote;
 #endif
+#ifdef __CUP_ZARGABAD__
+		_civVehiclesWeightedCityWealthLow;
+#endif
 #ifdef __CUP_SARA__
 		_civVehiclesWeightedCityWealthLow;
 #endif
@@ -1979,6 +1982,9 @@ d_base_apc_vec =
 		_mixedFaces;
 #endif
 #ifdef __CUP_TAKISTAN__
+		(_greekFaces + _persianFaces);
+#endif
+#ifdef __CUP_ZARGABAD__
 		(_greekFaces + _persianFaces);
 #endif
 #ifdef __CUP_SARA__

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -1796,7 +1796,218 @@ d_base_apc_vec =
 	d_noambient_bf_sounds = false;
 	
 	d_dbox_idx = 0;
+	
+	//civ vehicle definitions for each environment
+	_civVehiclesWeightedCityWealthHigh = [
+		"C_Offroad_01_F", 0.15,
+		"C_Hatchback_01_F", 0.30,
+		"C_Truck_02_covered_F", 0.05, 
+		"C_Van_01_box_F", 0.05,
+		"C_Van_02_transport_F", 0.05,
+		"C_Hatchback_01_sport_F", 0.10,
+		"C_Offroad_02_unarmed_F", 0.15,
+		"C_SUV_01_F", 0.15
+	];
+	
+	_civVehiclesWeightedCityWealthLow = [
+		"C_Offroad_01_F", 0.10,
+		"C_Hatchback_01_F", 0.10,
+		"C_Truck_02_covered_F", 0.03,
+		"C_Truck_02_transport_F", 0.03, 
+		"C_Van_01_box_F", 0.05,
+		"C_Van_02_transport_F", 0.05,
+		"C_Hatchback_01_sport_F", 0.05,
+		"C_Offroad_02_unarmed_F", 0.07,
+		"C_Hatchback_01_F", 0.35,
+		"C_SUV_01_F", 0.16
+	];
+	
+	_civVehiclesWeightedRural = [
+		"C_Offroad_01_F", 0.30,
+		"C_Truck_02_covered_F", 0.10,
+		"C_Truck_02_transport_F", 0.10, 
+		"C_Van_01_box_F", 0.05,
+		"C_Offroad_02_unarmed_F", 0.25,
+		"C_SUV_01_F", 0.15,
+		"C_Tractor_01_F", 0.10
+	];
+	
+	_civVehiclesWeightedRuralCup = [
+		"CUP_C_Golf4_random_Civ", 0.25,
+		"CUP_C_Datsun", 0.25,
+		"CUP_C_Octavia_CIV", 0.25,
+		"CUP_C_V3S_Covered_TKC", 0.20,
+		"C_Tractor_01_F", 0.05
+	];
+	
+	_civVehiclesWeightedRuralCupRemote = [
+		"CUP_C_Datsun", 0.35,
+		"CUP_C_Datsun_4seat", 0.35,
+		"CUP_C_V3S_Covered_TKC", 0.15,
+		"C_Tractor_01_F", 0.15
+	];
+	
+	_civVehiclesWeightedRuralLivonia = [
+		"C_Offroad_01_F", 0.30,
+		"C_Truck_02_transport_F", 0.15, 
+		"C_Offroad_02_unarmed_F", 0.30,
+		"C_SUV_01_F", 0.15,
+		"C_Tractor_01_F", 0.10
+	];
+	
+	_civVehiclesWeightedRuralGmcwg = [
+		"C_Truck_02_transport_F", 0.10,
+		"gm_gc_civ_p601", 0.40,
+		"gm_ge_civ_typ1200", 0.40,
+		"C_Tractor_01_F", 0.10
+	];
+	
+	d_civ_vehicles_weighted =
+#ifdef __ALTIS__
+		_civVehiclesWeightedCityWealthHigh;
+#endif
+#ifdef __CUP_CHERNARUS__
+		_civVehiclesWeightedRural;
+#endif
+#ifdef __CUP_TAKISTAN__
+		_civVehiclesWeightedRuralCupRemote;
+#endif
+#ifdef __CUP_SARA__
+		_civVehiclesWeightedCityWealthLow;
+#endif
+#ifdef __IFA3LITE__
+		_civVehiclesWeightedRural;
+#endif
+#ifdef __TANOA__
+		_civVehiclesWeightedCityWealthLow;
+#endif
+#ifdef __STRATIS__
+		_civVehiclesWeightedCityWealthHigh;
+#endif
+#ifdef __MALDEN__
+		_civVehiclesWeightedCityWealthLow;
+#endif
+#ifdef __ROSCHE__
+		_civVehiclesWeightedRural;
+#endif
+#ifdef __LIVONIA__
+		_civVehiclesWeightedRuralLivonia;
+#endif
+#ifdef __TT__
+		_civVehiclesWeightedRural;
+#endif
+#ifdef __GMCWG__
+		_civVehiclesWeightedRuralGmcwg;
+#endif
 };
+
+	//civilian faces
+	private _africanFaces = [
+		"AfricanHead_01",
+		"AfricanHead_02",
+		"AfricanHead_03"
+	];
+	private _asianFaces = [
+		"AsianHead_A3_01",
+		"AsianHead_A3_02",
+		"AsianHead_A3_03"
+	];
+	
+	private _greekFaces = [
+		"GreekHead_A3_01",
+		"GreekHead_A3_02",
+		"GreekHead_A3_03",
+		"GreekHead_A3_04",
+		"GreekHead_A3_05",
+		"GreekHead_A3_06",
+		"GreekHead_A3_07",
+		"GreekHead_A3_08",
+		"GreekHead_A3_09"
+		//GreekHead_A3_10_a //arid
+		//GreekHead_A3_10_l //lush
+		//GreekHead_A3_10_sa //unknown?
+	];
+	
+	private _persianFaces = [
+		"PersianHead_A3_01",
+		"PersianHead_A3_02",
+		"PersianHead_A3_03"
+		//PersianHead_A3_04_a
+		//PersianHead_A3_04_l
+		//PersianHead_A3_04_sa
+	];
+	
+	private _whiteFaces = [
+		"WhiteHead_01",
+		"WhiteHead_02",
+		"WhiteHead_03",
+		"WhiteHead_04",
+		"WhiteHead_05",
+		"WhiteHead_06",
+		"WhiteHead_07",
+		"WhiteHead_08",
+		"WhiteHead_09",
+		"WhiteHead_10",
+		"WhiteHead_11",
+		"WhiteHead_12",
+		"WhiteHead_13",
+		"WhiteHead_14",
+		"WhiteHead_15",
+		"WhiteHead_16",
+		"WhiteHead_17",
+		"WhiteHead_18",
+		"WhiteHead_19",
+		"WhiteHead_20",
+		"WhiteHead_21"
+		//WhiteHead_22_a
+		//WhiteHead_22_l
+		//WhiteHead_22_sa
+	];
+	
+	private _mixedFaces = _greekFaces + _persianFaces + _whiteFaces;
+	
+	//todo - do these work?
+	//WomanHead_A3
+	//MaskHead_A3
+	//BlackHead_A3
+
+	d_civ_faces =
+#ifdef __ALTIS__
+		_mixedFaces;
+#endif
+#ifdef __CUP_CHERNARUS__
+		_mixedFaces;
+#endif
+#ifdef __CUP_TAKISTAN__
+		(_greekFaces + _persianFaces);
+#endif
+#ifdef __CUP_SARA__
+		_mixedFaces;
+#endif
+#ifdef __IFA3LITE__
+		_mixedFaces;
+#endif
+#ifdef __TANOA__
+		_asianFaces;
+#endif
+#ifdef __STRATIS__
+		_mixedFaces;
+#endif
+#ifdef __MALDEN__
+		_mixedFaces;
+#endif
+#ifdef __ROSCHE__
+		_whiteFaces;
+#endif
+#ifdef __LIVONIA__
+		_whiteFaces;
+#endif
+#ifdef __TT__
+		_mixedFaces;
+#endif
+#ifdef __GMCWG__
+		_whiteFaces;
+#endif
 
 if (hasInterface) then {
 	__TRACE("preInit hasInterface")

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
@@ -101,11 +101,12 @@ while {true} do {
 				if (([_unit, _x] call _isVisible) || {[_unit, _x, 360] call _isLOS}) then {
 					//to check if unit actually fired
                 	_ammoCount = _unit ammo primaryWeapon _unit;
+                	_magazineCount = count magazinesAmmo _unit; 
 					// execute aggressive shooting
 					_unit doTarget _x;
 					_unit doSuppressiveFire _x;
 					sleep 15;
-					if (_ammoCount > _unit ammo primaryWeapon _unit) then {
+					if (_ammoCount > _unit ammo primaryWeapon _unit || _magazineCount > count magazinesAmmo _unit) then {
                     	//yes the unit actually fired
                     	_fired = true;
                     	_lastFired = time;

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -22,46 +22,46 @@ if (isNil "d_cur_tgt_civ_modules_presenceunit") then {
 //create civilian module
 private _placeCivilianSpotsAndUnits = {
 	//_randomPos = [[[_trg_center, 200]],[]] call BIS_fnc_randomPos;
-	_ms1 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,125] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms1 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms1 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms1;
 	__TRACE_1("","_ms1")
 
-	_ms2 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,125] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms2 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms2 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms2;
 	__TRACE_1("","_ms2")
 
-	_ms3 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,125] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms3 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms3 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms3;
 	__TRACE_1("","_ms3")
 
-	_ms4 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,125] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms4 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms4 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms4;
 	__TRACE_1("","_ms4")
 
-	_ms5 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,200] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms5 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms5 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms5;
 	__TRACE_1("","_ms5")
 
-	_ms6 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,200] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms6 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,50] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms6 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms6;
 	__TRACE_1("","_ms6")
 
-	_ms7 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,200] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms7 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,100] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms7 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms7;
 	__TRACE_1("","_ms7")
 
-	_mu1 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,50] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_mu1 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	d_cur_tgt_civ_modules_presenceunit pushBack _mu1;
 	__TRACE_1("","_mu1")
 
-	_mu2 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,50] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_mu2 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	d_cur_tgt_civ_modules_presenceunit pushBack _mu2;
 	__TRACE_1("","_mu2")
 };
@@ -109,5 +109,66 @@ for "_i" from 0 to d_civ_groupcount do {
 		_this addEventHandler ["Killed", {
 			_this call d_fnc_civmodulekilleh;
 		}];
+		[_this, selectRandom d_civ_faces] remoteExec ["setIdentity", 0, _this];
+#ifdef __CUP_CHERNARUS__
+		_this setUnitLoadout selectRandom [
+			"CUP_C_C_Citizen_01",
+			"CUP_C_C_Citizen_02",
+			"CUP_C_C_Citizen_03",
+			"CUP_C_C_Citizen_04",
+			"CUP_C_C_Worker_01",
+			"CUP_C_C_Worker_02",
+			"CUP_C_C_Worker_03",
+			"CUP_C_C_Worker_04",
+			"CUP_C_C_Profiteer_01",
+			"CUP_U_C_Profiteer_01",
+			"CUP_C_C_Profiteer_02",
+			"CUP_C_C_Profiteer_03",
+			"CUP_C_C_Profiteer_04",
+			"CUP_C_C_Woodlander_01",
+			"CUP_C_C_Woodlander_02",
+			"CUP_C_C_Woodlander_03",
+			"CUP_C_C_Woodlander_04",
+			"CUP_C_C_Villager_01",
+			"CUP_C_C_Villager_02",
+			"CUP_C_C_Villager_03",	
+			"CUP_C_C_Villager_04",
+			"CUP_C_C_Priest_01"
+		];
+#endif
+#ifdef __CUP_TAKISTAN__
+		_this setUnitLoadout selectRandom [
+			"CUP_C_TK_Man_05_Waist",
+			"CUP_C_TK_Man_06_Waist",
+			"CUP_C_TK_Man_01_Coat",
+			"CUP_C_TK_Man_08_Waist",
+			"CUP_C_TK_Man_03_Coat",
+			"CUP_C_TK_Man_01_Jack",
+			"CUP_C_TK_Man_06_Jack",
+			"CUP_C_TK_Man_03_Jack",
+			"CUP_C_TK_Man_03_Jack"
+		];
+#endif
+#ifdef __TANOA__
+		_this setUnitLoadout selectRandom [
+			"C_Man_casual_1_F_tanoan",
+			"C_Man_casual_2_F_tanoan",
+			"C_Man_casual_3_F_tanoan",
+			"C_Man_casual_4_F_tanoan",
+			"C_Man_casual_5_F_tanoan",
+			"C_Man_casual_6_F_tanoan"
+		];
+#endif
+#ifdef __LIVONIA__
+		_this setUnitLoadout selectRandom [
+			"C_Man_1_enoch_F",
+			"C_Man_2_enoch_F",
+			"C_Man_3_enoch_F",
+			"C_Man_4_enoch_F",
+			"C_Man_5_enoch_F",
+			"C_Man_6_enoch_F",
+			"C_Farmer_01_enoch_F"
+		];
+#endif
 	}];
 };

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -149,6 +149,19 @@ for "_i" from 0 to d_civ_groupcount do {
 			"CUP_C_TK_Man_03_Jack"
 		];
 #endif
+#ifdef __CUP_ZARGABAD__
+		_this setUnitLoadout selectRandom [
+			"CUP_C_TK_Man_05_Waist",
+			"CUP_C_TK_Man_06_Waist",
+			"CUP_C_TK_Man_01_Coat",
+			"CUP_C_TK_Man_08_Waist",
+			"CUP_C_TK_Man_03_Coat",
+			"CUP_C_TK_Man_01_Jack",
+			"CUP_C_TK_Man_06_Jack",
+			"CUP_C_TK_Man_03_Jack",
+			"CUP_C_TK_Man_03_Jack"
+		];
+#endif
 #ifdef __TANOA__
 		_this setUnitLoadout selectRandom [
 			"C_Man_casual_1_F_tanoan",

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -418,20 +418,6 @@ if (d_enable_civ_vehs > 0) then {
 	
 	_roadList= _trg_center nearroads d_enable_civ_vehs_rad;
 	
-	_civVehiclesWeighted = [
-		"C_Offroad_01_F", 0.10,
-		"C_Hatchback_01_F", 0.10,
-		"C_Truck_02_covered_F", 0.03,
-		"C_Truck_02_transport_F", 0.03, 
-		"C_Van_01_box_F", 0.05,
-		"C_Van_02_transport_F", 0.05,
-		"C_Hatchback_01_sport_F", 0.05,
-		"C_Offroad_02_unarmed_F", 0.07,
-		"C_Hatchback_01_F", 0.35,
-		"C_SUV_01_F", 0.16,
-		"C_Tractor_01_F", 0.01
-		];
-	
 	if (isNil "d_cur_tgt_civ_vehicles") then {
 		d_cur_tgt_civ_vehicles = [];
 	};	
@@ -457,7 +443,7 @@ if (d_enable_civ_vehs > 0) then {
 			_connectedRoad = _roadConnectedTo select 0;
 			_direction = [_currentRoad, _connectedRoad] call BIS_fnc_DirTo;
 			
-			_veh = createVehicle [selectRandomWeighted _civVehiclesWeighted, _currentRoad, [], 0, "NONE"];
+			_veh = createVehicle [selectRandomWeighted d_civ_vehicles_weighted, _currentRoad, [], 0, "NONE"];
 			if (d_enable_civ_vehs_locked == 1) then {
 				_veh lock true;
 			};


### PR DESCRIPTION
added: parameter option for very low number of civilian vehicles better for very small villages, civilian vehicles are now determined by which map is selected (no more shiny sports cars in villages), civilians unit models are now determined by which map is selected, civilians now have randomized faces grouped by head type

fixed: civilians now have a smaller spawn and movement radius to wander less, ammo check loop now accounts for magazine reload