### PR TITLE
fixed: ambush group movement now only triggered if firedNear firer is an enemy

### DIFF
--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -216,11 +216,14 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 									};
 
 									_uuidx setVariable ["zen_fn_idx2", _uuidx addEventHandler ["FiredNear", {
+										params ["_unit", "_firer", "_distance", "_weapon", "_muzzle", "_mode", "_ammo", "_gunner"];
 										scriptName "spawn_zoh_firednear1ambush";
-										(_this select 0) enableAI "TARGET";
-										(_this select 0) enableAI "AUTOTARGET";
-										(_this select 0) enableAI "MOVE";
-										(_this select 0) forceSpeed -1;
+										if (side _firer == d_side_player) then {
+											(_this select 0) enableAI "TARGET";
+											(_this select 0) enableAI "AUTOTARGET";
+											(_this select 0) enableAI "MOVE";
+											(_this select 0) forceSpeed -1;
+										};
 									}]];
 								};
 


### PR DESCRIPTION
Fixes the wave of enemies upon initial contact.  Enemy bots were firing and triggering all ambush groups in the entire target area within the first minute of combat.