### PR TITLE
parameter to allow camps to simulate penetration and damage

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -626,6 +626,13 @@ class Params {
 		default = 0;
 		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
 	};
+	
+	class d_EnableSimulationCamps {
+		title = "$STR_DOM_MISSIONSTRING_ENABLESIMCAMPS";
+		values[] = {1,0};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
+	};
 
 	class d_params_dl_5 {
 		title = "$STR_DOM_MISSIONSTRING_1572";

--- a/co30_Domination.Altis/scripts/fn_createsimpleobject.sqf
+++ b/co30_Domination.Altis/scripts/fn_createsimpleobject.sqf
@@ -83,12 +83,17 @@ if (_class == "" && {_p3d == ""}) exitWith {
 private _superSimple = _class == "" || {_forceSuperSimple};
 
 //create simple object
-private _object = if (_superSimple) then {
+private _object = nil;
+if (_superSimple) then {
 	//World coords are used
-	createSimpleObject [_p3d, _pos, _loc];
+	_object = createSimpleObject [_p3d, _pos, _loc];
 } else {
-	//ASL coords are used; fixed later by ASL to World offset
-	createSimpleObject [_class, _pos, _loc];
+	if (d_EnableSimulationCamps > 0) then {
+		_object = createVehicle [_class, _pos, [], 0, "NONE"];
+	} else {
+		//ASL coords are used; fixed later by ASL to World offset
+		_object = createSimpleObject [_class, AGLToASL _pos, _loc];
+	};
 };
 
 if (isNull _object) exitWith {

--- a/co30_Domination.Altis/scripts/fn_objectsmapper.sqf
+++ b/co30_Domination.Altis/scripts/fn_objectsmapper.sqf
@@ -151,8 +151,10 @@ private _multiplyMatrixFunc = {
 #ifdef __CUP__
 			if (!(_type isKindOf "StaticWeapon") && {_type isKindOf "Tank_F" || {_type isKindOf "Car_F" || {_type == "Land_tent_east"}}}) then {
 				_newObj lock true;
-				_newObj enableSimulationGlobal false;
-				_newObj allowDamage false;
+				if (d_EnableSimulationCamps == 0) then {
+					_newObj enableSimulationGlobal false;
+					_newObj allowDamage false;
+				};
 				clearWeaponCargoGlobal _newObj;
 				clearMagazineCargoGlobal _newObj;
 				clearItemCargoGlobal _newObj;
@@ -172,7 +174,7 @@ private _multiplyMatrixFunc = {
 				_newPos = _newPos vectorAdd [0, 0, 0.1];
 			};
 			__TRACE_2("","_newPos","AGLToASL _newPos")
-			_newObj = [_type, AGLToASL _newPos, 0, true, false, _loc] call d_fnc_createSimpleObject;
+			_newObj = [_type, _newPos, 0, true, false, _loc] call d_fnc_createSimpleObject;
 			_newObj setDir (_azi + _azimuth);
 			_newPos = getPosWorld _newObj;
 			__TRACE_1("before","_newPos")

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -7177,6 +7177,18 @@
 <Chinese>玩家能禁用草:</Chinese>
 <French>Le joueur peut désactiver l'herbe:</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_ENABLESIMCAMPS">
+<English>Enable simulation for enemy camps:</English>
+<Spanish>Enable simulation for enemy camps:</Spanish>
+<Portuguese>Enable simulation for enemy camps:</Portuguese>
+<Korean>Enable simulation for enemy camps:</Korean>
+<Japanese>Enable simulation for enemy camps:</Japanese>
+<Original>Enable simulation for enemy camps:</Original>
+<Russian>Enable simulation for enemy camps:</Russian>
+<Chinesesimp>Enable simulation for enemy camps:</Chinesesimp>
+<Chinese>Enable simulation for enemy camps:</Chinese>
+<French>Enable simulation for enemy camps:</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1176">
 <English>Recruit AI (max.):</English>
 <Spanish>Recrutar AI (máx.):</Spanish>


### PR DESCRIPTION
added: parameter to toggle creating camps with createVehicle vs createSimpleObject to allow penetration and damage of camp objects

The parameter default matches to current default with simulation disabled.  The current camps look very cool but it breaks immersion to see rocket hit an Ifrit and see no damage or see bullets stopped by a camo net.  I would like this parameter enabled by default but it depends on your preference for network efficiency.  :)