### PR TITLE
added: new missiontype where side missions now spawn close to main target and must be cleared before main target is considered clear

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -370,9 +370,9 @@ class Params {
 
 	class d_MissionType {
 		title = "$STR_DOM_MISSIONSTRING_1052";
-		values[] = {0,1,2};
+		values[] = {0,1,2,3};
 		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_1053","$STR_DOM_MISSIONSTRING_1054","$STR_DOM_MISSIONSTRING_1055"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_1053","$STR_DOM_MISSIONSTRING_1054","$STR_DOM_MISSIONSTRING_1055","$STR_DOM_MISSIONSTRING_1055_MAIN_AND_SIDE"};
 	};
 	
 	class d_with_ranked {

--- a/co30_Domination.Altis/missions/common/fn_sideevac.sqf
+++ b/co30_Domination.Altis/missions/common/fn_sideevac.sqf
@@ -14,6 +14,8 @@ _wreck setPos _poss;
 _wreck lock true;
 d_x_sm_vec_rem_ar pushBack _wreck;
 
+private _distanceToEnablePilotMovement = 20;
+
 sleep 2;
 
 private _owngroup = [d_side_player] call d_fnc_creategroup;
@@ -21,7 +23,12 @@ if (d_with_ai) then {
 	_owngroup setVariable ["d_do_not_delete", true];
 };
 __TRACE_1("","_owngroup")
-private _nposss = _poss findEmptyPosition [20, 100, d_sm_pilottype];
+private _nposss = [];
+if (d_MissionType == 3) then {
+	_nposss = _poss findEmptyPosition [10, 25, d_sm_pilottype];
+} else {
+	_nposss = _poss findEmptyPosition [20, 100, d_sm_pilottype];
+};
 if (_nposss isEqualTo []) then {_nposss = _poss};
 private _pilot1 = _owngroup createUnit [d_sm_pilottype, _nposss, [], 0, "NONE"];
 _pilot1 allowDamage false;
@@ -44,6 +51,46 @@ _pilot2 disableAI "RADIOPROTOCOL";
 
 private _otrig = [_pilot1, [800, 800, 0, false, 10], ["ANYPLAYER", "PRESENT", true], ["this", "[thisTrigger, 0] call d_fnc_trigwork", "[thisTrigger, 1] call d_fnc_trigwork"]] call d_fnc_createtriggerlocal;
 _otrig setVariable ["d_objs", [_pilot1, _pilot2]];
+
+if (d_MissionType == 3) then {
+
+	[
+		_poss,											// Params: 1. Array, the building(s) nearest this position is used
+		[_pilot1],									//         2. Array of objects, the units that will garrison the building(s)
+		65,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+		false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
+		true,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
+		true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
+		false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
+		2   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
+	] call d_fnc_Zen_OccupyHouse;
+	
+	[
+		([[[_poss, [15,45] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
+		[_pilot2],									//         2. Array of objects, the units that will garrison the building(s)
+		65,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+		false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
+		true,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
+		true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
+		false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
+		2   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
+	] call d_fnc_Zen_OccupyHouse;
+
+
+	sleep 1;
+	_pilot1 setUnitPos "DOWN";
+	_pilot2 setUnitPos "DOWN";
+	_owngroup setCombatMode "BLUE";
+	sleep 180;
+	//180 seconds then good luck, boys.
+	if (alive _pilot1) then {
+		_pilot1 allowDamage true;
+	};
+	if (alive _pilot2) then {
+		_pilot2 allowDamage true;
+	};
+	_distanceToEnablePilotMovement = 1.5;
+};
 
 sleep 15;
 _pilot1 disableAI "PATH";
@@ -95,7 +142,7 @@ while {!_pilots_at_base && {!_is_dead && {!d_sm_resolved}}} do {
 			__TRACE("not rescued")
 			if (alive _pilot1) then {
 				__TRACE("_pilot1 alive")
-				private _nobjs = (_pilot1 nearEntities ["CAManBase", 20]) select {alive _x && {(_x call d_fnc_isplayer) && {!(_x getVariable ["xr_pluncon", false]) && {!(_x getVariable ["ace_isunconscious", false])}}}};
+				private _nobjs = (_pilot1 nearEntities ["CAManBase", _distanceToEnablePilotMovement]) select {alive _x && {(_x call d_fnc_isplayer) && {!(_x getVariable ["xr_pluncon", false]) && {!(_x getVariable ["ace_isunconscious", false])}}}};
 				if !(_nobjs isEqualTo []) then {
 					_resctimestarted = time;
 					_rescued = true;
@@ -107,7 +154,7 @@ while {!_pilots_at_base && {!_is_dead && {!d_sm_resolved}}} do {
 			if (!_rescued) then {
 				if (alive _pilot2) then {
 					__TRACE("_pilot2 alive")
-					private _nobjs = (_pilot2 nearEntities ["CAManBase", 20]) select {alive _x && {(_x call d_fnc_isplayer) && {!(_x getVariable ["xr_pluncon", false]) && {!(_x getVariable ["ace_isunconscious", false])}}}};
+					private _nobjs = (_pilot2 nearEntities ["CAManBase", _distanceToEnablePilotMovement]) select {alive _x && {(_x call d_fnc_isplayer) && {!(_x getVariable ["xr_pluncon", false]) && {!(_x getVariable ["ace_isunconscious", false])}}}};
 					if !(_nobjs isEqualTo []) then {
 						_resctimestarted = time;
 						_rescued = true;

--- a/co30_Domination.Altis/missions/common/fn_sideevac.sqf
+++ b/co30_Domination.Altis/missions/common/fn_sideevac.sqf
@@ -55,22 +55,22 @@ _otrig setVariable ["d_objs", [_pilot1, _pilot2]];
 if (d_MissionType == 3) then {
 
 	[
-		_poss,											// Params: 1. Array, the building(s) nearest this position is used
+		([[[_poss, 35]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
 		[_pilot1],									//         2. Array of objects, the units that will garrison the building(s)
-		65,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+		-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
 		false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
-		true,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
+		false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 		true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
 		false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
 		2   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
 	] call d_fnc_Zen_OccupyHouse;
 	
 	[
-		([[[_poss, [15,45] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
+		([[[_poss, 35]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
 		[_pilot2],									//         2. Array of objects, the units that will garrison the building(s)
-		65,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+		-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
 		false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
-		true,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
+		false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 		true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
 		false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
 		2   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
@@ -80,6 +80,8 @@ if (d_MissionType == 3) then {
 	sleep 1;
 	_pilot1 setUnitPos "DOWN";
 	_pilot2 setUnitPos "DOWN";
+	_pilot1 forceSpeed 0;
+	_pilot2 forceSpeed 0;
 	_owngroup setCombatMode "BLUE";
 	sleep 180;
 	//180 seconds then good luck, boys.
@@ -89,7 +91,7 @@ if (d_MissionType == 3) then {
 	if (alive _pilot2) then {
 		_pilot2 allowDamage true;
 	};
-	_distanceToEnablePilotMovement = 1.5;
+	_distanceToEnablePilotMovement = 3;
 };
 
 sleep 15;
@@ -117,6 +119,7 @@ private _pcheck_fnc = {
 		private _ogroup = group _x;
 		_x setUnitPos "AUTO";
 		_x enableAI "PATH";
+		_x forceSpeed -1;
 		[_x] join _p;
 		deleteGroup _ogroup;
 	} forEach _u;
@@ -227,3 +230,4 @@ if (!isNull _otrig) then {
 sleep 0.5;
 
 d_sm_resolved = true;
+d_sm_nearby_cleared = true;

--- a/co30_Domination.Altis/missions/common/fn_sideevac.sqf
+++ b/co30_Domination.Altis/missions/common/fn_sideevac.sqf
@@ -162,10 +162,6 @@ while {!_pilots_at_base && {!_is_dead && {!d_sm_resolved}}} do {
 						deleteVehicle _otrig;
 					};
 				};
-				
-				if (!_rescued && {time - _resctimestarted > 3600}) then {
-					_is_dead = true;
-				};
 			};
 		} else {
 #ifndef __TT__
@@ -184,78 +180,11 @@ while {!_pilots_at_base && {!_is_dead && {!d_sm_resolved}}} do {
 			if (alive _pilot1 && {!(leader (group _pilot1) call d_fnc_isplayer)} || {alive _pilot2 && {!(leader (group _pilot2) call d_fnc_isplayer)}}) then {
 				_rescued = false;
 			};
-			if (time - _resctimestarted > 3600) then {
-				_is_dead = true;
-			};
 		};
 	};
 
 	sleep 5.621;
-	if (_time_over > 0) then {
-		if (_time_over == 3) then {
-			if (_endtime - time <= 600) then {
-				_time_over = 2;
-#ifndef __TT__
-				[23] call d_fnc_DoKBMsg;
-#else
-				[24] call d_fnc_DoKBMsg;
-#endif
-			};
-		} else {
-			if (_time_over == 2) then {
-				if (_endtime - time <= 300) then {
-					_time_over = 1;
-#ifndef __TT__
-					[25] call d_fnc_DoKBMsg;
-#else
-					[26] call d_fnc_DoKBMsg;
-#endif
-				};
-			} else {
-				if (_time_over == 1) then {
-					if (_endtime - time <= 120) then {
-						_time_over = 0;
-#ifndef __TT__
-						[27] call d_fnc_DoKBMsg;
-#else
-						[28] call d_fnc_DoKBMsg;
-#endif
-					};
-				};
-			};
-		};
-	} else {
-		if (!_enemy_created) then {
-			_enemy_created = true;
-			if (alive _pilot1) then {
-				_pilot1 allowDamage true;
-			};
-			if (alive _pilot2) then {
-				_pilot2 allowDamage true;
-			};
-			deleteVehicle _otrig;
-			private _estart_pos = [_poss, 250] call d_fnc_GetRanPointCircleOuter;
-			private _unit_array = ["allmen", d_enemy_side_short] call d_fnc_getunitlistm;
-			for "_i" from 1 to ([3,5] call d_fnc_GetRandomRangeInt) do {
-				private _newgroup = [d_enemy_side] call d_fnc_creategroup;
-				private _units = [_estart_pos, _unit_array, _newgroup, false, true] call d_fnc_makemgroup;
-				_newgroup deleteGroupWhenEmpty true;
-				sleep 1.045;
-				private _leader = leader _newgroup;
-				_leader setRank "LIEUTENANT";
-				_newgroup allowFleeing 0;
-				_newgroup setBehaviour "AWARE";
-				private _gwp = _newgroup addWaypoint [_poss, 30];
-				_gwp setWaypointtype "SAD";
-				_gwp setWaypointCombatMode "YELLOW";
-				_gwp setWaypointSpeed "FULL";
-				d_x_sm_rem_ar append _units;
-				{_x triggerDynamicSimulation true} forEach _units;
-				sleep 1.012;
-			};
-			_unit_array = nil;
-		};
-	};
+	
 };
 
 if (!d_sm_resolved) then {

--- a/co30_Domination.Altis/missions/embed/x_m51.sqf
+++ b/co30_Domination.Altis/missions/embed/x_m51.sqf
@@ -3,13 +3,11 @@
 #define THIS_FILE "x_m51.sqf"
 #include "..\..\x_setup.sqf"
 
-//d_x_sm_pos = [[9255.93,8234.52,0]]; // index: 51,   Shot down chopper
 d_x_sm_pos = [([[[(markerPos "d_sm_51"), [0,10] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos)]; // index: 51,   Shot down chopper
-//d_x_sm_pos = [(markerPos "d_sm_51")]; // index: 51,   Shot down chopper
 d_x_sm_type = "evac";
 
 if (hasInterface) then {
-	d_cur_sm_txt = localize "STR_DOM_MISSIONSTRING_1803";
+	d_cur_sm_txt = localize "STR_DOM_MISSIONSTRING_1803_NO_TIMER";
 	d_current_mission_resolved_text = localize "STR_DOM_MISSIONSTRING_812";
 };
 

--- a/co30_Domination.Altis/missions/embed/x_m51.sqf
+++ b/co30_Domination.Altis/missions/embed/x_m51.sqf
@@ -1,0 +1,18 @@
+// by Xeno
+//#define __DEBUG__
+#define THIS_FILE "x_m51.sqf"
+#include "..\..\x_setup.sqf"
+
+//d_x_sm_pos = [[9255.93,8234.52,0]]; // index: 51,   Shot down chopper
+d_x_sm_pos = [([[[(markerPos "d_sm_51"), [0,10] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos)]; // index: 51,   Shot down chopper
+//d_x_sm_pos = [(markerPos "d_sm_51")]; // index: 51,   Shot down chopper
+d_x_sm_type = "evac";
+
+if (hasInterface) then {
+	d_cur_sm_txt = localize "STR_DOM_MISSIONSTRING_1803";
+	d_current_mission_resolved_text = localize "STR_DOM_MISSIONSTRING_812";
+};
+
+if (isServer) then {
+	[d_x_sm_pos, time + ((15 * 60) + random 60)] spawn d_fnc_sideevac;
+};

--- a/co30_Domination.Altis/missions/fn_clearsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_clearsidemission.sqf
@@ -45,4 +45,6 @@ d_x_sm_vec_rem_ar = [];
 {deleteVehicle _x} forEach (d_x_sm_rem_ar select {!isNull _x});
 d_x_sm_rem_ar = [];
 d_sm_resolved = false;
-0 spawn d_fnc_getsidemission;
+if (d_MissionType != 3) then {
+	0 spawn d_fnc_getsidemission;
+};

--- a/co30_Domination.Altis/missions/fn_clearsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_clearsidemission.sqf
@@ -9,7 +9,7 @@ if (!isNil "d_sm_check_trigger") then {
 };
 
 private _waittime = 200 + random 10;
-if (d_MissionType != 2) then {
+if (d_MissionType == 0) then {
 	private _num_p = call d_fnc_PlayersNumber;
 	if (_num_p > 0) then {
 		private _fidx = d_time_until_next_sidemission findIf {_num_p <= _x # 0};
@@ -17,6 +17,10 @@ if (d_MissionType != 2) then {
 			_waittime = ((d_time_until_next_sidemission # _fidx # 1) max 20) + random 10;
 		};
 	};
+};
+
+if (d_MissionType == 3) then {
+	_waittime = 45;
 };
 
 sleep _waittime;

--- a/co30_Domination.Altis/missions/fn_getsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_getsidemission.sqf
@@ -32,37 +32,33 @@ private _cur_sm_idx = nil;
 private _smpos = [[0, 0, 0]];
 private _smkey = "";
 private _iter = 0;
+private _sm_selected_size_at_start = 0;
+
+if (!isNil "d_sm_selected" && {!(d_sm_selected isEqualTo [])}) then {
+	_sm_selected_size_at_start = count d_sm_selected;
+};
 
 if (d_MissionType == 3) then {	
 	
-	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smpos # 0: %1", _smpos # 0]];
-	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smkey: %1", _smkey]];
+	waitUntil {
+		!isNil "d_cur_tgt_pos" && {!(d_cur_tgt_pos isEqualTo []) && {!isNil "d_sm_array" && {!(d_sm_array isEqualTo [])}}}
+	};
 	
-	
-	while {true} do {
-		waitUntil {
-			!isNil "d_cur_tgt_pos" && !(d_cur_tgt_pos isEqualTo []) && !isNil "d_side_missions_random" && !(d_side_missions_random isEqualTo [])
-		};
-	
-		diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo2 too far: %1 %2", _smkey, _smpos]];
-		_iter = _iter + 1;
-
-		_cur_sm_idx = d_side_missions_random # _iter;
-		_smkey = "d_sm_" + str _cur_sm_idx;
+	{
+		_smkey = "d_sm_" + str _x;
 		_smpos = _smkey call d_fnc_smmapos;
-		
 		//select sidemission if within max distance from main target and not previously selected
 		if ((d_cur_tgt_pos distance2D (_smpos # 0) < d_sm_max_distance_from_mt) && (d_sm_selected findIf { _x == _smkey } == -1)) exitWith {
 			//add to selected array
 			d_sm_selected pushBack _smkey;
+			_cur_sm_idx = _x;
 		};
-		if (_iter == d_number_side_missions) then {
-			//failed to find a sidemission near the main target, try again later
-			_iter = 0;
-			d_sm_nearby_cleared = true;
-			sleep 90;
-		};
+	} forEach d_sm_array;
+	
+	if ((count d_sm_selected) == _sm_selected_size_at_start) then {
+		d_sm_nearby_cleared = true;
 	};
+	
 } else {
 	_cur_sm_idx = d_side_missions_random # d_current_mission_counter;
 	d_current_mission_counter = d_current_mission_counter + 1;
@@ -73,4 +69,6 @@ __TRACE_1("","_cur_sm_idx")
 //_cur_sm_idx = _this select 0;
 //_cur_sm_idx = 50042;
 
-[_cur_sm_idx] spawn d_fnc_hcsmexec;
+if (!isNil "_cur_sm_idx") then {
+	[_cur_sm_idx] spawn d_fnc_hcsmexec;
+};

--- a/co30_Domination.Altis/missions/fn_getsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_getsidemission.sqf
@@ -56,6 +56,7 @@ if (d_MissionType == 3) then {
 	} forEach d_sm_array;
 	
 	if ((count d_sm_selected) == _sm_selected_size_at_start) then {
+		//unable to find a sidemission that fits our criteria so just set cleared to true
 		d_sm_nearby_cleared = true;
 	};
 	

--- a/co30_Domination.Altis/missions/fn_getsidemission.sqf
+++ b/co30_Domination.Altis/missions/fn_getsidemission.sqf
@@ -28,8 +28,45 @@ if (d_MissionType != 2) then {
 };
 #endif
 
-private _cur_sm_idx = d_side_missions_random # d_current_mission_counter;
-d_current_mission_counter = d_current_mission_counter + 1;
+private _cur_sm_idx = nil;
+private _smpos = [[0, 0, 0]];
+private _smkey = "";
+private _iter = 0;
+
+if (d_MissionType == 3) then {	
+	
+	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smpos # 0: %1", _smpos # 0]];
+	diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo _smkey: %1", _smkey]];
+	
+	
+	while {true} do {
+		waitUntil {
+			!isNil "d_cur_tgt_pos" && !(d_cur_tgt_pos isEqualTo []) && !isNil "d_side_missions_random" && !(d_side_missions_random isEqualTo [])
+		};
+	
+		diag_log [diag_frameno, diag_ticktime, time, format["foooooooooooooo2 too far: %1 %2", _smkey, _smpos]];
+		_iter = _iter + 1;
+
+		_cur_sm_idx = d_side_missions_random # _iter;
+		_smkey = "d_sm_" + str _cur_sm_idx;
+		_smpos = _smkey call d_fnc_smmapos;
+		
+		//select sidemission if within max distance from main target and not previously selected
+		if ((d_cur_tgt_pos distance2D (_smpos # 0) < d_sm_max_distance_from_mt) && (d_sm_selected findIf { _x == _smkey } == -1)) exitWith {
+			//add to selected array
+			d_sm_selected pushBack _smkey;
+		};
+		if (_iter == d_number_side_missions) then {
+			//failed to find a sidemission near the main target, try again later
+			_iter = 0;
+			d_sm_nearby_cleared = true;
+			sleep 90;
+		};
+	};
+} else {
+	_cur_sm_idx = d_side_missions_random # d_current_mission_counter;
+	d_current_mission_counter = d_current_mission_counter + 1;
+};
 
 __TRACE_1("","_cur_sm_idx")
 

--- a/co30_Domination.Altis/missions/missionssetup.sqf
+++ b/co30_Domination.Altis/missions/missionssetup.sqf
@@ -255,6 +255,11 @@ d_sm_folder = "ma3m";
 d_sm_folder = "mifa3";
 #endif
 
+//if mission type has an embedded sidemission then override the ifdefs above
+if (d_MissionType == 3) then {
+	d_sm_folder = "embed";
+};
+
 // Instead of a random vehicle chosen for winning a side mission you can setup it in the mission yourself now
 // Add d_current_sm_bonus_vec to the beginning of a sidemission script with a vehicle class string and that vehicle gets chosen instead of a random one.
 // Examples:

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -108,21 +108,41 @@ if (_buildingRadius < 0) then {
 	_buildingsArray = _buildingsArray0 arrayIntersect _buildingsArray1;
 };
 
-if (count _buildingsArray == 0) exitWith {
-	diag_log "Zen_Occupy House Error : No buildings found.";
-	[]
-};
-
 _buildingPosArray = [];
 0 = [_buildingsArray] call _Zen_ArrayShuffle;
+
+//try to avoid choosing buildings already occupied by players or friendlies
 {
 	_posArray = _x buildingPos -1;
 	if !(_posArray isEqualTo []) then {
-		_buildingPosArray pushBack _posArray;
+		
+		private _isEligible = true;
+		private _distancePlayerSideTooClose = 5;
+		{
+			
+			private _xx = _x; //_xx is the position being tested
+			
+			{
+				if (alive _x && {_x isKindOf "CAManBase" && {side _x == d_side_player }}) then {
+					_isEligible = false;
+				}
+			} forEach (_xx nearEntities _distancePlayerSideTooClose);
+			
+			if (_isEligible) then {
+				_buildingPosArray pushBack _posArray;
+			}	
+		
+		} forEach _posArray;
+		
 	};
 } forEach _buildingsArray;
 
 __TRACE_1("","_buildingPosArray")
+
+if (count _buildingsArray == 0) exitWith {
+	diag_log "Zen_Occupy House Error : No buildings found.";
+	[]
+};
 
 if (_sortHeight) then {
 	{
@@ -269,8 +289,8 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 								} else {
 									breakTo "while";
 								};
-							};
-						};
+							};//end if
+						};//end if
 					};//end if
 				};//end if
 			};//end if

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -150,6 +150,7 @@ __TRACE_1("","_this")
 
 if (d_MissionType == 3) then {
 	d_sm_nearby_cleared = false;
+	0 spawn d_fnc_getsidemission;
 };
 d_groups_respawn_time_add = 0;
 //limit barracks by d_max_bar_cnt, default is very high but may be lower if mission settings are non-default

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -148,6 +148,9 @@ __TRACE_1("","_trg_center")
 __TRACE_3("","_trgobj","_radius","_patrol_radius")
 __TRACE_1("","_this")
 
+if (d_MissionType == 3) then {
+	d_sm_nearby_cleared = false;
+};
 d_groups_respawn_time_add = 0;
 //limit barracks by d_max_bar_cnt, default is very high but may be lower if mission settings are non-default
 d_num_barracks_objs = ((ceil random 7) max 4) min d_max_bar_cnt;

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -150,7 +150,11 @@ __TRACE_1("","_this")
 
 if (d_MissionType == 3) then {
 	d_sm_nearby_cleared = false;
-	0 spawn d_fnc_getsidemission;
+	//0 spawn d_fnc_getsidemission;
+	//51 is a chopper pilot rescue and has been modified to randomly select chopper location
+	private _p = [[[_trg_center, [175,250] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos;
+	"d_sm_51" setMarkerPos _p;
+	[51] spawn d_fnc_hcsmexec;
 };
 d_groups_respawn_time_add = 0;
 //limit barracks by d_max_bar_cnt, default is very high but may be lower if mission settings are non-default

--- a/co30_Domination.Altis/server/fn_createnexttarget.sqf
+++ b/co30_Domination.Altis/server/fn_createnexttarget.sqf
@@ -72,13 +72,13 @@ __TRACE("!d_update_target done")
 #ifndef __TT__
 _tsar = call {
 	if (d_ao_check_for_ai == 0) exitWith {
-		["d_mt_radio_down && {d_campscaptured == d_sum_camps}", "0 = 0 spawn d_fnc_target_clear", ""]
+		["d_mt_radio_down && {d_sm_nearby_cleared && {d_campscaptured == d_sum_camps}}", "0 = 0 spawn d_fnc_target_clear", ""]
 	};
 	if (d_ao_check_for_ai == 1) exitWith {
-		["d_mt_radio_down && {d_campscaptured == d_sum_camps && {'Car' countType thislist <= d_car_count_for_target_clear && {'Tank' countType thislist <= d_tank_count_for_target_clear && {'Man' countType thislist <= d_man_count_for_target_clear}}}}", "0 = 0 spawn d_fnc_target_clear", ""]
+		["d_mt_radio_down && {d_sm_nearby_cleared && {d_campscaptured == d_sum_camps && {'Car' countType thislist <= d_car_count_for_target_clear && {'Tank' countType thislist <= d_tank_count_for_target_clear && {'Man' countType thislist <= d_man_count_for_target_clear}}}}}", "0 = 0 spawn d_fnc_target_clear", ""]
 	};
 	if (d_ao_check_for_ai == 2) exitWith {
-		["d_mt_radio_down && {'Car' countType thislist <= d_car_count_for_target_clear && {'Tank' countType thislist <= d_tank_count_for_target_clear && {'Man' countType thislist <= d_man_count_for_target_clear}}}", "0 = 0 spawn d_fnc_target_clear", ""]
+		["d_mt_radio_down && {d_sm_nearby_cleared && {'Car' countType thislist <= d_car_count_for_target_clear && {'Tank' countType thislist <= d_tank_count_for_target_clear && {'Man' countType thislist <= d_man_count_for_target_clear}}}}", "0 = 0 spawn d_fnc_target_clear", ""]
 	};
 };
 #else

--- a/co30_Domination.Altis/server/fn_setupserver.sqf
+++ b/co30_Domination.Altis/server/fn_setupserver.sqf
@@ -8,7 +8,8 @@ d_last_bonus_vec = "";
 
 d_sm_selected = [];
 d_sm_max_distance_from_mt = 2000;
-d_sm_nearby_cleared = false;
+//if d_MissionType == 3 then this flag is later set to false in createmaintarget
+d_sm_nearby_cleared = true;
 
 d_sm_triggervb = [
 	[0, 0, 0],

--- a/co30_Domination.Altis/server/fn_setupserver.sqf
+++ b/co30_Domination.Altis/server/fn_setupserver.sqf
@@ -24,7 +24,7 @@ d_sm_triggervb = [
 
 if (d_with_ai) then {0 spawn d_fnc_delaiserv};
 
-if (d_MissionType in [0,2,3]) then {
+if (d_MissionType in [0,2]) then {
 	0 spawn {
 		scriptName "spawn_serversetup_startsm";
 		sleep 20;
@@ -38,9 +38,6 @@ if (d_MissionType in [0,2,3]) then {
 					_waittime = ((d_time_until_next_sidemission # _fidx # 1) max 20) + random 10;
 				};
 			};
-		};
-		if (d_MissionType == 3) then {
-			_waittime = 45;
 		};
 		sleep _waittime;
 		0 spawn d_fnc_getsidemission;

--- a/co30_Domination.Altis/server/fn_setupserver.sqf
+++ b/co30_Domination.Altis/server/fn_setupserver.sqf
@@ -7,11 +7,8 @@ if (!isServer) exitWith {};
 d_last_bonus_vec = "";
 
 d_sm_selected = [];
-d_sm_max_distance_from_mt = 1400;
-d_sm_nearby_cleared = true;
-if (d_MissionType == 3) then {
-	d_sm_nearby_cleared = false;
-};
+d_sm_max_distance_from_mt = 2000;
+d_sm_nearby_cleared = false;
 
 d_sm_triggervb = [
 	[0, 0, 0],

--- a/co30_Domination.Altis/server/fn_setupserver.sqf
+++ b/co30_Domination.Altis/server/fn_setupserver.sqf
@@ -6,6 +6,13 @@ if (!isServer) exitWith {};
 
 d_last_bonus_vec = "";
 
+d_sm_selected = [];
+d_sm_max_distance_from_mt = 1400;
+d_sm_nearby_cleared = true;
+if (d_MissionType == 3) then {
+	d_sm_nearby_cleared = false;
+};
+
 d_sm_triggervb = [
 	[0, 0, 0],
 	[0, 0, 0, false, 0],
@@ -19,23 +26,25 @@ d_sm_triggervb = [
 
 if (d_with_ai) then {0 spawn d_fnc_delaiserv};
 
-if (d_MissionType in [0,2]) then {
+if (d_MissionType in [0,2,3]) then {
 	0 spawn {
 		scriptName "spawn_serversetup_startsm";
 		sleep 20;
-		if (d_MissionType != 2) then {
+		private _waittime = 15;
+		if (d_MissionType == 0) then {
 			private _num_p = call d_fnc_PlayersNumber;
-			private _waittime = 200 + random 10;
+			_waittime = 200 + random 10;
 			if (_num_p > 0) then {
 				private _fidx = d_time_until_next_sidemission findIf {_num_p <= _x # 0};
 				if (_fidx > -1) then {
 					_waittime = ((d_time_until_next_sidemission # _fidx # 1) max 20) + random 10;
 				};
 			};
-			sleep _waittime;
-		} else {
-			sleep 15;
 		};
+		if (d_MissionType == 3) then {
+			_waittime = 45;
+		};
+		sleep _waittime;
 		0 spawn d_fnc_getsidemission;
 	};
 };

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -6456,12 +6456,12 @@
 <French>Missions de type:</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1053">
-<English>Main Targets and Side Missions (default)</English>
+<English>Main Targets and Side Missions (Default)</English>
 <Spanish>Misiones por Defecto</Spanish>
 <Portuguese>Tipo de missão padrão</Portuguese>
 <Korean>기본 미션 종류</Korean>
 <Japanese>デフォルトのミッションタイプ</Japanese>
-<Original>Main Targets and Side Missions (default)</Original>
+<Original>Main Targets and Side Missions (Default)</Original>
 <Russian>Города и доп.задания</Russian>
 <Chinesesimp>默认任务类型</Chinesesimp>
 <Chinese>默認任務類型</Chinese>
@@ -6492,14 +6492,14 @@
 <French>Missions secondaires uniquement</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1055_MAIN_AND_SIDE">
-<English>Main Targets and Nearby Side Missions</English>
-<Spanish>Main Targets and Nearby Side Missions</Spanish>
-<Portuguese>Main Targets and Nearby Side Missions</Portuguese>
-<Korean>Main Targets and Nearby Side Missions</Korean>
-<Japanese>Main Targets and Nearby Side Missions</Japanese>
-<Original>Main Targets and Nearby Side Missions</Original>
-<Russian>Main Targets and Nearby Side Missions</Russian>
-<Chinesesimp>Main Targets and Nearby Side Missions</Chinesesimp>
+<English>Main Targets and Nearby Side Mission</English>
+<Spanish>Main Targets and Nearby Side Mission</Spanish>
+<Portuguese>Main Targets and Nearby Side Mission</Portuguese>
+<Korean>Main Targets and Nearby Side Mission</Korean>
+<Japanese>Main Targets and Nearby Side Mission</Japanese>
+<Original>Main Targets and Nearby Side Mission</Original>
+<Russian>Main Targets and Nearby Side Mission</Russian>
+<Chinesesimp>Main Targets and Nearby Side Mission</Chinesesimp>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1056">
 <English>Teleport or spawn at MHQ:</English>
@@ -11002,12 +11002,12 @@
 <French>Créer ATV</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1817">
-<English>A high enemy government member is visiting some enemy troops. Find him and elimante him!</English>
+<English>A high enemy government member is visiting some enemy troops. Find him and eliminate him!</English>
 <Spanish>Un alto miembro del gobierno enemigo está visitando algunas tropas enemigas. ¡Encuéntralo y elimínalo!</Spanish>
 <Portuguese>Um alto membro do governo inimigo está visitando algumas tropas inimigas. Encontrem-no e eliminem-no!</Portuguese>
 <Korean>적 정부의 고위급 인사가 적 부대를 방문 중입니다. 그를 찾고 사살하십시오!</Korean>
-<Japanese>A high enemy government member is visiting some enemy troops. Find him and elimante him!</Japanese>
-<Original>A high enemy government member is visiting some enemy troops. Find him and elimante him!</Original>
+<Japanese>A high enemy government member is visiting some enemy troops. Find him and eliminate him!</Japanese>
+<Original>A high enemy government member is visiting some enemy troops. Find him and eliminate him!</Original>
 <Russian>Высокопоставленный член правительства решил посетить подразделения противника. Найдите и ликвидируйте его!</Russian>
 <Chinesesimp>一个敌方的高级政府成员正在慰问军队。找到他并消灭他！</Chinesesimp>
 <Chinese>一個敵方的高級政府成員正在慰問軍隊。找到他並消滅他！</Chinese>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="Domination">
 <Package name="Domination">
 <Container name="Mission">
@@ -6456,12 +6456,12 @@
 <French>Missions de type:</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1053">
-<English>Default Mission Type</English>
+<English>Main Targets and Side Missions (default)</English>
 <Spanish>Misiones por Defecto</Spanish>
 <Portuguese>Tipo de missão padrão</Portuguese>
 <Korean>기본 미션 종류</Korean>
 <Japanese>デフォルトのミッションタイプ</Japanese>
-<Original>Default Mission Type</Original>
+<Original>Main Targets and Side Missions (default)</Original>
 <Russian>Города и доп.задания</Russian>
 <Chinesesimp>默认任务类型</Chinesesimp>
 <Chinese>默認任務類型</Chinese>
@@ -6490,6 +6490,16 @@
 <Chinesesimp>只有支线任务</Chinesesimp>
 <Chinese>只有支線任務</Chinese>
 <French>Missions secondaires uniquement</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1055_MAIN_AND_SIDE">
+<English>Main Targets and Nearby Side Missions</English>
+<Spanish>Main Targets and Nearby Side Missions</Spanish>
+<Portuguese>Main Targets and Nearby Side Missions</Portuguese>
+<Korean>Main Targets and Nearby Side Missions</Korean>
+<Japanese>Main Targets and Nearby Side Missions</Japanese>
+<Original>Main Targets and Nearby Side Missions</Original>
+<Russian>Main Targets and Nearby Side Missions</Russian>
+<Chinesesimp>Main Targets and Nearby Side Missions</Chinesesimp>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1056">
 <English>Teleport or spawn at MHQ:</English>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10845,6 +10845,18 @@
 <Chinese>我們的一架直升機被擊落。找到並拯救機組成員並將他們帶回基地。注意，敵軍也在通往直升機墜機點的路上。你要在敵軍前15分鐘到達</Chinese>
 <French>Un de nos hélicoptères a été abattu. Trouvez et sauvez l'équipage et ramenez-le à la base. Attention, les unités ennemies sont également en route vers l'hélico. Vous avez environ 15 minutes avant leur arrivée</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1803_NO_TIMER">
+<English>One of our choppers was shot down. Find and rescue the crew and bring them back to base.</English>
+<Spanish>Uno de nuestros helicópteros fue derribado. Encuentra y rescata a la tripulación y llévalos a la base.</Spanish>
+<Portuguese>Um de nossos helicópteros foi abatido. Encontre e resgate a tripulação e traga-os de volta para a base.</Portuguese>
+<Korean>우리의 헬기중 한대가 격추되었습니다. 승무원을 찾고 구조해서 기지로 데려오십시오.</Korean>
+<Japanese>One of our choppers was shot down. Find and rescue the crew and bring them back to base.</Japanese>
+<Original>One of our choppers was shot down. Find and rescue the crew and bring them back to base.</Original>
+<Russian>Есть сообщение о сбитом вертолете. Нужно спасти экипаж и доставить его на базу.</Russian>
+<Chinesesimp>我们的一架直升机被击落。找到并拯救机组成员并将他们带回基地。</Chinesesimp>
+<Chinese>我們的一架直升機被擊落。找到並拯救機組成員並將他們帶回基地。注意，</Chinese>
+<French>Un de nos hélicoptères a été abattu. Trouvez et sauvez l'équipage et ramenez-le à la base.</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1804">
 <English>Energy is key in any modern war. We want you to sabotage the enemy power supplies. Destroy the transformer station!</English>
 <Spanish>La energía es clave en cualquier guerra moderna. Queremos que sabotees los suministros de energía del enemigo. Destruye la estación transformadora!</Spanish>


### PR DESCRIPTION
This code selects sidemissions that are near the current maintarget with a new d_MissionType == 3. 
 This is a continuation of PR #115 but adds the sidemission as a victory requirement for maintarget.