### PR TITLE
fixed: missing semicolon was causing the guerrilla tanks event to fail, minor changes to event descriptions

### DIFF
--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -76,7 +76,7 @@ if (d_with_dynsim == 0) then {
 
 sleep 2.333;
 
-private _enemyGuardGroup = ["specops", 1, "allmen", 0, _poss , 25, false, true] call d_fnc_CreateInf select 0;
+private _enemyGuardGroup = ["specops", 1, "allmen", 0, _poss , 12, false, true, 3] call d_fnc_CreateInf select 0;
 {
 	[_x, 30] call d_fnc_nodamoffdyn;
 	_x forceSpeed 0;

--- a/co30_Domination.Altis/missions/events/fn_event_tanksincoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_tanksincoming.sqf
@@ -14,11 +14,44 @@ if !(isServer) exitWith {};
 if (true) exitWith {};
 #endif
 
-private _eventArmor = "I_MBT_03_cannon_F";
+//armor types
+private _eventArmorHeavy = "I_MBT_03_cannon_F";
+private _eventArmorMedium = "I_APC_tracked_03_cannon_F";
+private _eventArmorLight = "I_LT_01_cannon_F";
 
 #ifdef __IFA3LITE__
-_eventArmor = "LIB_StuG_III_G";
+_eventArmorHeavy = "LIB_PzKpfwIV_H";
+_eventArmorMedium = "LIB_StuG_III_G";
+_eventArmorLight = "LIB_SdKfz251";
 #endif
+
+//array of armor vehicles to create
+private _eventArmorAll = [];
+switch (d_WithLessArmor) do {
+	case 0: {
+		_eventArmorAll = [
+			_eventArmorHeavy,
+			_eventArmorHeavy,
+			_eventArmorMedium,
+			_eventArmorLight
+		];
+	};
+	case 1: {
+		_eventArmorAll = [
+			_eventArmorHeavy,
+			_eventArmorMedium,
+			_eventArmorLight,
+			_eventArmorLight
+		];	
+	};
+	case 2: {
+		_eventArmorAll = [
+			_eventArmorMedium,
+			_eventArmorLight,
+			_eventArmorLight
+		];
+	};
+};
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
@@ -61,24 +94,19 @@ d_kb_logic1 kbTell [
 	d_kbtel_chan
 ];
 
-for "_i" from 1 to _numberOfTanks do {
-	private _veh = createVehicle [_eventArmor, _roadList select _i, [], 0, "NONE"];
+private _iter = 0;
+{
+	private _veh = createVehicle [_x, _roadList select _iter, [], 0, "NONE"];
+	_iter = _iter + 1;
 	_x_mt_event_ar pushBack _veh;
 	_veh call d_fnc_nodamoff;
-	sleep 3;
-	private _hhe = createVehicle [d_HeliHEmpty, getPosATL _veh, [], 0, "NONE"];
-    _veh setPos (getPosATL _hhe);
-    deleteVehicle _hhe;
-    sleep 3;
+	sleep 5;
 	private _newgroup = createVehicleCrew _veh;
 	_newgroups pushBack _newgroup;
-	{
-		_x call d_fnc_nodamoff;
-	} forEach units _newgroup;
     if (d_with_ai) then {
     	_newgroup setVariable ["d_do_not_delete", true];
     };
-};
+} forEach _eventArmorAll;
 
 sleep 3.14;
 

--- a/co30_Domination.Altis/missions/fn_createinf.sqf
+++ b/co30_Domination.Altis/missions/fn_createinf.sqf
@@ -13,7 +13,8 @@ __TRACE_1("","_this")
 // 4. _pos_center
 // 5. _radius
 // 6. _do_patrol
-// 7. _isArmorAdjustmentDisabled (default: false) if true do not modify the specified number of groups regardless of "no enemy armor" setting
+// 7. _isArmorAdjustmentDisabled (optional, default: false) if true do not modify the specified number of groups regardless of "no enemy armor" setting
+// 8. _unitsPerGroup (optional) if defined then this number sets the number of units created per group (will not be randomized)
 
 private _pos_center = _this select 4;
 if (isNil "_pos_center") exitWith {
@@ -27,6 +28,7 @@ private _radius = _this select 5;
 private _do_patrol = if (_radius < 50) then {false} else {if (count _this == 7) then {_this select 6} else {false}};
 private _ret_grps = [];
 private _isArmorAdjustmentDisabled = if (count _this > 7) then {_this select 7} else {false};
+private _unitsPerGroup = if (count _this > 8) then {_this select 8} else {-1};
 
 for "_nr" from 0 to 1 do {
 	private _nrg = _this select (1 + (_nr * 2));
@@ -53,7 +55,7 @@ for "_nr" from 0 to 1 do {
 				_pos = _pos_center;
 			};
 			__TRACE("from createinf")
-			private _units = [_pos, [_typenr, d_enemy_side_short] call d_fnc_getunitlistm, _newgroup, true, true] call d_fnc_makemgroup;
+			private _units = [_pos, [_typenr, d_enemy_side_short] call d_fnc_getunitlistm, _newgroup, true, true, _unitsPerGroup] call d_fnc_makemgroup;
 			_newgroup deleteGroupWhenEmpty true;
 			_newgroup allowFleeing 0;
 			if (!_do_patrol) then {

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
@@ -83,7 +83,7 @@ while {true} do {
 	_Dtargets = [];
 
 	{
-		if (alive _x && {_x isKindOf "CAManBase" && {!(vehicle _unit isKindOf "Air") && {side _x == _targetSide && {_x distance2D _unit < _detectionRadius}}}}) then {
+		if (isPlayer _x && {alive _x && {_x isKindOf "CAManBase" && {!(vehicle _unit isKindOf "Air") && {side _x == _targetSide && {_x distance2D _unit < _detectionRadius}}}}}) then {
 			if (_awarenessRadius > 0 && {_x getVariable ["xr_pluncon", false] || {_x getVariable ["ace_isunconscious", false]}}) then {
 				_unit reveal [_x, 4];
 			};

--- a/co30_Domination.Altis/server/fn_makemgroup.sqf
+++ b/co30_Domination.Altis/server/fn_makemgroup.sqf
@@ -3,7 +3,7 @@
 #define THIS_FILE "fn_makemgroup.sqf"
 #include "..\x_setup.sqf"
 
-params ["_pos", "_unitliste", "_grp", ["_mchelper", true], ["_doreduce", false]];
+params ["_pos", "_unitliste", "_grp", ["_mchelper", true], ["_doreduce", false], ["_unitsPerGroup", -1]];
 
 if (isNil "_unitliste") exitWith {
 	diag_log ["Attention, _unitlist (param 2) is nil, returning []", "_pos", _pos, "_grp", _grp];
@@ -35,7 +35,16 @@ if (d_smallgrps == 0 && {_doreduce && {count _unitliste > 2}}) then {
 		};
 		0.26
 	};
-	private _maxunits = round (_factor * _nump) max (selectRandom [2, 3]);
+	
+	
+	private _maxunits = 99;
+	
+	if (_unitsPerGroup > 0) then {
+    	_maxunits = _unitsPerGroup;
+    } else {
+    	_maxunits = round (_factor * _nump) max (selectRandom [2, 3]);
+    };
+	
 	__TRACE_3("","_nump","_factor","_maxunits")
 	if (_maxunits < count _unitliste) then {
 		private _tmpar =+ _unitliste;

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -13360,16 +13360,16 @@
 <French>Leak sealed!</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_2028">
-<English>Attention: Guerrilla tanks are moving into the city from %1.</English>
-<Spanish>Attention: Guerrilla tanks are moving into the city from %1.</Spanish>
-<Portuguese>Attention: Guerrilla tanks are moving into the city from %1.</Portuguese>
-<Korean>Attention: Guerrilla tanks are moving into the city from %1.</Korean>
-<Japanese>Attention: Guerrilla tanks are moving into the city from %1.</Japanese>
-<Original>Attention: Guerrilla tanks are moving into the city from %1.</Original>
-<Russian>Attention: Guerrilla tanks are moving into the city from %1.</Russian>
-<Chinesesimp>注意：游击队坦克正在进入城市。%1</Chinesesimp>
-<Chinese>Attention: Guerrilla tanks are moving into the city from %1.</Chinese>
-<French>Attention: Guerrilla tanks are moving into the city from %1.</French>
+<English>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</English>
+<Spanish>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Spanish>
+<Portuguese>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Portuguese>
+<Korean>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Korean>
+<Japanese>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Japanese>
+<Original>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Original>
+<Russian>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Russian>
+<Chinesesimp>注意：游击队坦克正在进入城市。%1 The guerrillas are friendly to Blufor and hostile to Opfor.</Chinesesimp>
+<Chinese>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</Chinese>
+<French>Attention: Guerrilla tanks are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_2029">
 <English>We have the chance to retake one of our farps the enemy had seized some time ago. Go get it back!</English>


### PR DESCRIPTION
Tank event now has mixed armor units.

Also added a parameter for createinf and makemgroup to allow the exact number of units to be set (not random).