### PR TITLE
Allow ACE arsenal if arsenal restrictions are disabled

### DIFF
--- a/co30_Domination.Altis/client/fn_inventoryopened.sqf
+++ b/co30_Domination.Altis/client/fn_inventoryopened.sqf
@@ -34,11 +34,12 @@ if (_box getVariable ["d_player_ammobox", false]) then {
 			scriptName "spawn_inventoryopened1";
 			d_has_opened_arsenal = true;
 			if (!d_with_ranked) then {
-				//if (!d_with_ace) then {
+				if (d_with_ace && d_arsenal_mod == 1) then {
+					[player, player, true] call ace_arsenal_fnc_openBox;
+
+				} else {
 					["Open", true] call bis_fnc_arsenal;
-				//} else {
-				//	[player, player, true] call ace_arsenal_fnc_openBox;
-				//};
+				};
 			} else {
 				if (!d_no_ranked_weapons) then {
 					["Open", [nil, player]] call bis_fnc_arsenal;

--- a/co30_Domination.Altis/client/x_setupplayer.sqf
+++ b/co30_Domination.Altis/client/x_setupplayer.sqf
@@ -824,7 +824,7 @@ if (isNil "d_cas_plane_avail") then {
 player addEventhandler["InventoryOpened", {_this call d_fnc_inventoryopened}];
 player addEventhandler["InventoryClosed", {_this call d_fnc_inventoryclosed}];
 
-//if (!d_with_ace || {d_with_ranked}) then {
+if (!d_with_ace || {d_with_ranked}) then {
 [missionNamespace, "arsenalOpened", {
 	_this call d_fnc_arsenalopened;
 }] call BIS_fnc_addScriptedEventHandler;
@@ -832,15 +832,15 @@ player addEventhandler["InventoryClosed", {_this call d_fnc_inventoryclosed}];
 [missionNamespace, "arsenalClosed", {
 	call d_fnc_arsenalclosed;
 }] call BIS_fnc_addScriptedEventHandler;
-//} else {
-//	["ace_arsenal_displayOpened", {
-//		_this call d_fnc_arsenalopened;
-//	}] call CBA_fnc_addEventHandler;
+} else {
+	["ace_arsenal_displayOpened", {
+		_this call d_fnc_arsenalopened;
+	}] call CBA_fnc_addEventHandler;
 
-//	["ace_arsenal_displayClosed", {
-//		_this call d_fnc_arsenalopened;
-//	}] call CBA_fnc_addEventHandler;
-//};
+	["ace_arsenal_displayClosed", {
+		_this call d_fnc_arsenalopened;
+	}] call CBA_fnc_addEventHandler;
+};
 
 player addEventhandler ["HandleRating", {
 	if ((_this select 1) < 0) then {0} else {_this select 1}


### PR DESCRIPTION
When merged, this commit will allow ACE arsenal to be used only if ACE is present and "Use only mod weapons in Virtual Arsenal" is false.