### PR TITLE
added: main target locations can now be smaller location types

### DIFF
--- a/co30_Domination.Altis/server/fn_maketarget_names.sqf
+++ b/co30_Domination.Altis/server/fn_maketarget_names.sqf
@@ -12,10 +12,18 @@
 		d_target_names pushBack [_pos, _name, _dtar getVariable ["d_cityradius", 300], _forEachIndex, _dtar];
 	} else {
 		private _nlocs = nearestLocations [getPosWorld _dtar, ["NameCityCapital", "NameCity", "NameVillage"], 500];
+		// if _pos is more than 500m from a NameCityCapital/NameCity/NameVillage then try again with more location types
+		if (_nlocs isEqualTo []) then {
+			_nlocs = nearestLocations [getPosWorld _dtar, ["Area","BorderCrossing","CityCenter","CivilDefense","CulturalProperty","DangerousForces","Flag","FlatArea","FlatAreaCity","FlatAreaCitySmall","Hill","HistoricalSite","Invisible","Mount","Name","NameCity","NameCityCapital","NameLocal","NameMarine","NameVillage","RockArea","SafetyZone","Strategic","StrongpointArea","VegetationBroadleaf","VegetationFir","VegetationPalm","VegetationVineyard","ViewPoint"], 500];
+		};
 		__TRACE_2("","_dtar","_nlocs")
 		if !(_nlocs isEqualTo []) then {
 			private _locposnl0 = locationPosition (_nlocs # 0);
 			private _nl = nearestLocations [_locposnl0, ["CityCenter"], 300];
+			// if _pos is more than 300m from a CityCenter then try again with more location types
+			if (_nl isEqualTo []) then {
+				_nl = nearestLocations [_locposnl0, ["Area","BorderCrossing","CityCenter","CivilDefense","CulturalProperty","DangerousForces","Flag","FlatArea","FlatAreaCity","FlatAreaCitySmall","Hill","HistoricalSite","Invisible","Mount","Name","NameCity","NameCityCapital","NameLocal","NameMarine","NameVillage","RockArea","SafetyZone","Strategic","StrongpointArea","VegetationBroadleaf","VegetationFir","VegetationPalm","VegetationVineyard","ViewPoint"], 300];
+			};
 			__TRACE_2("","_locposnl0","_nl")
 			private _pos = [_locposnl0, locationPosition (_nl # 0)] select !(_nl isEqualTo []);
 			_pos set [2, 0];
@@ -23,6 +31,9 @@
 				_dtar setPos _pos;
 			};
 			_name = text (_nlocs # 0);
+			if (_name == "") then {
+				_name = "Unnamed Target";
+			};
 			_dtar setVariable ["d_cityname", _name];
 			d_target_names pushBack [_pos, _name, _dtar getVariable ["d_cityradius", 300], _forEachIndex, _dtar];
 		} else {


### PR DESCRIPTION
I think this is safe?

I added an empty check if a target marker does not match the allowed location types.  If the marker is not within 500m of a matching location type then it will search again for any location type (filtered on the entire type list).

This allows mission editors to paste a target marker anywhere on the map.  I did not actually add any target markers to mission.sqm but anyone should be able to do modify in Eden.  There are beautiful locations in the southwest part of Altis... :)