### PR TITLE
added: maintarget AI leave persistent corpses until the target is cleared, not implemented for sidemissions yet

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -458,6 +458,13 @@ default = 7;
 		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
 	};
 	
+	class d_ai_persistent_corpses {
+		title = "$STR_DOM_MISSIONSTRING_1741_CORPSES";
+		values[] = {0,1};
+		default = 1;
+		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
+	};
+	
 	class d_params_dl_8_env {
 		title = "$STR_DOM_MISSIONSTRING_1574_ENV";
 		values[] = {-99999};

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -106,6 +106,10 @@ for "_i" from 0 to d_civ_groupcount do {
 	_m setVariable ["#unitcount", d_civ_unitcount];
 	_m setVariable ["#onCreated", {
 		d_cur_tgt_civ_units pushBack _this;
+		if (d_ai_persistent_corpses == 0) then {
+			// civ corposes are removed when civ module is deleted
+			removeFromRemainsCollector [_this];
+		};
 		_this addEventHandler ["Killed", {
 			_this call d_fnc_civmodulekilleh;
 		}];

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -25,9 +25,12 @@ private _garrisonUnits = {
 		_sniperGrpName = format["Sniper%1", floor(random 999999)];
 		_newgroup setGroupId [_sniperGrpName];
 	};
-	
+
+#ifndef __TT__
+	private _units_to_garrison = [_trg_center, _unitlist, _newgroup, false, true, -1, d_side_player, "MAIN"] call d_fnc_makemgroup;
+#else
 	private _units_to_garrison = [_trg_center, _unitlist, _newgroup, false, true] call d_fnc_makemgroup;
-	
+#endif	
 	if (_unitMovementMode == 2) then {
 		{
 			_x disableAI "PATH";
@@ -409,7 +412,11 @@ if (d_no_more_observers < 2) then {
 		private _xpos = _wp_array_inf select _xx_ran;
 		_wp_array_inf deleteAt _xx_ran;
 		__TRACE("from createmaintarget 1")
+#ifndef __TT__
+		private _observer = ([_xpos, _unit_array, _agrp, true, false, -1, d_side_player, "MAIN"] call d_fnc_makemgroup) # 0;
+#else
 		private _observer = ([_xpos, _unit_array, _agrp, true, false] call d_fnc_makemgroup) # 0;
+#endif
 		_agrp deleteGroupWhenEmpty true;
 		[_agrp, _xpos, [_trg_center, _radius], [5, 20, 40], "", 0] spawn d_fnc_MakePatrolWPX;
 		_agrp setVariable ["d_PATR", true];

--- a/co30_Domination.Altis/server/fn_makegroup.sqf
+++ b/co30_Domination.Altis/server/fn_makegroup.sqf
@@ -51,7 +51,11 @@ if (_numvecs > 0) then {
 	_msize = 2;
 } else {
 	__TRACE("from makegroup")
+#ifndef __TT__
+	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true, -1, d_side_player, "MAIN"] call d_fnc_makemgroup;
+#else
 	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true] call d_fnc_makemgroup;
+#endif
 	__TRACE_1("","_uinf")
 };
 

--- a/co30_Domination.Altis/server/fn_makemgroup.sqf
+++ b/co30_Domination.Altis/server/fn_makemgroup.sqf
@@ -168,6 +168,17 @@ if (side _grp == d_side_enemy) then {
 (leader _grp) setRank "SERGEANT";
 #ifndef __TT__
 if (d_ai_awareness_rad > 0 || {d_snp_aware > 0 || {d_ai_pursue_rad > 0 || {d_ai_aggressiveshoot > 0}}}) then {
+	if (isNil "_sideToEngage") then {
+		//not working, not sure why???
+		//_sideToEngage = d_player_side; // output:  Error Undefined variable in expression: d_player_side ????
+		//workaround
+		if (side (leader _grp) == east) then {
+			_sideToEngage = west;
+		} else {
+			_sideToEngage = east;
+		};
+	};
+	
 	//advanced awareness
 	if (["Sniper", groupId(_grp)] call BIS_fnc_inString) then {
 		{

--- a/co30_Domination.Altis/server/fn_spawncrew.sqf
+++ b/co30_Domination.Altis/server/fn_spawncrew.sqf
@@ -6,6 +6,22 @@
 params ["_vec", "_grp", ["_nocargo", false]];
 
 private _uavgrp = createVehicleCrew _vec;
+if (d_ai_persistent_corpses == 0) then {
+	if (isNil "d_cur_tgt_inf_units") then {
+    	d_cur_tgt_inf_units = [];
+    };
+	{
+		removeFromRemainsCollector [_x];
+		d_cur_tgt_inf_units pushBack _x;
+		_x addEventHandler ["Killed", {
+			_this spawn {
+				scriptName "special cleanup rules for persistent corpses";
+				waitUntil {sleep 63.14; d_mt_done};
+				deleteVehicle (_this select 0);
+			};
+		}];
+	} forEach (units _uavgrp);
+};
 private _crew = crew _vec;
 if (count _crew > 0) then {
 	_crew joinSilent _grp;

--- a/co30_Domination.Altis/server/fn_target_clear.sqf
+++ b/co30_Domination.Altis/server/fn_target_clear.sqf
@@ -175,6 +175,14 @@ if (d_enable_civs == 1) then {
 		deleteVehicle _x;
 	} forEach d_cur_tgt_civ_units;
 	
+	//cleanup mgroup units
+	if (d_ai_persistent_corpses == 0) then {
+		{
+			deleteVehicle _x;
+		} forEach d_cur_tgt_inf_units;
+		d_cur_tgt_inf_units = [];
+	};
+	
 	//cleanup civ vehicles after 300 secs
 	d_cur_tgt_civ_units = [];
 	private _tmpCivVehs = +d_cur_tgt_civ_vehicles;

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10693,6 +10693,18 @@
 <Chinese>重新生成主要目標的敵方AI當做增援：</Chinese>
 <French>Réapparition du groupe d'IA en renfort de l'objectif principal:</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1741_CORPSES">
+<English>Persistent AI corpses</English>
+<Spanish>Persistent AI corpses</Spanish>
+<Portuguese>Persistent AI corpses</Portuguese>
+<Korean>Persistent AI corpses</Korean>
+<Japanese>Persistent AI corpses</Japanese>
+<Original>Persistent AI corpses</Original>
+<Russian>Persistent AI corpses</Russian>
+<Chinesesimp>Persistent AI corpses</Chinesesimp>
+<Chinese>Persistent AI corpses</Chinese>
+<French>Persistent AI corpses</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1742">
 <English>Attach wreck</English>
 <Spanish>Adjuntar Chatarra</Spanish>


### PR DESCRIPTION
This pull request adds support for corpses to remain on the ground where they fall until the maintarget is cleared.  This adds a very dark but interesting visual after an extended firefight...

![image](https://user-images.githubusercontent.com/46298219/92163570-ed30d580-ee01-11ea-8224-cc37df3be847.png)

This seems to have only minor performance impact on the server, perhaps more performance impact on the client.  I think the visual improvement to the environment is worth it however.  Very interesting when you walk through areas more than one time.

The implementation adds parameters to d_fnc_makemgroup signature and should be backward compatible.  This can support sidemissions but I could not think of a variable to while watch for sidemissions, maintarget has d_mt_done but nothing for sidemissions... perhaps if we can determine an easy way to trigger a cleanup then it can be added to side missions too.  I also did not want to modify all the sidemission code, maybe some other day.  It was easy to add the new parameters to createmaintarget.sqf so that was my approach for now.

As always, I attempted to avoid changing the default gameplay.  If the "persistent corpses" parameter is turned off then this code will have no affect.