### PR TITLE
fixed: guerrilla infantry sometimes spawned too close to maintarget

### DIFF
--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -55,7 +55,7 @@ private _midpoint_pos = [
 ];
 
 private _spawn_pos = _midpoint_pos;
-if ((_midpoint_pos distance2D _target_center) < 250) then {
+if ((_midpoint_pos distance2D _target_center) < 375) then {
 	// midpoint is too close to maintarget, instead use location position
 	_spawn_pos = _townNearbyPos;
 };

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -53,6 +53,13 @@ private _midpoint_pos = [
 	((_target_center # 0) + (_townNearbyPos # 0))/2,
 	((_target_center # 1) + (_townNearbyPos # 1))/2
 ];
+
+private _spawn_pos = _midpoint_pos;
+if ((_midpoint_pos distance2D _target_center) < 250) then {
+	// midpoint is too close to maintarget, instead use location position
+	_spawn_pos = _townNearbyPos;
+};
+
 private _newgroups = [];
 private _guerrillaForce = ["allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "specops"];
 private _guerrillaBaseSkill = 0.35;
@@ -60,7 +67,7 @@ private _guerrillaBaseSkill = 0.35;
 {
 	private _unitlist = [_x, "G"] call d_fnc_getunitlistm;
 	private _newgroup = [independent] call d_fnc_creategroup;
-	private _units = [_midpoint_pos, _unitlist, _newgroup, false, true, 5, opfor] call d_fnc_makemgroup;
+	private _units = [_spawn_pos, _unitlist, _newgroup, false, true, 5, opfor] call d_fnc_makemgroup;
 	{
 		_x setSkill _guerrillaBaseSkill;
 		_x setSkill ["spotTime", 0.6];


### PR DESCRIPTION
The guerrilla spawn position was being calculated by finding the midpoint between the maintarget and the nearest location.  Sometimes that was too close to the maintarget so if midpoint is less than 375m then just use position of the nearest location and ignore midpoint calculation.