### PR TITLE
added: parameter to announce enemy artillery or CAS without capturing intel

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -977,6 +977,13 @@ default = 7;
 		default = -99999;
 		texts[] = {""};
 	};
+	
+	class d_tell_arty_cas {
+		title = "$STR_DOM_MISSIONSTRING_1894_TELL_ARTY_CAS";
+		values[] = {0,1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+	};
 
 	class d_disable_airai {
 		title = "$STR_DOM_MISSIONSTRING_1894";

--- a/co30_Domination.Altis/server/fn_shootari.sqf
+++ b/co30_Domination.Altis/server/fn_shootari.sqf
@@ -17,7 +17,7 @@ private _type = call {
 
 private _num_shells = if (_kind in [0, 1]) then {
 #ifndef __TT__
-	if (d_searchintel # 4 == 1) then {
+	if (d_searchintel # 4 == 1 || { d_tell_arty_cas == 1 }) then {
 #else
 	if (floor random 3 == 0) then {
 #endif

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -12073,6 +12073,18 @@
 <Chinese>Disable enemy air</Chinese>
 <French>Désactiver l'aérien ennemi</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1894_TELL_ARTY_CAS">
+<English>Always announce enemy artillery / CAS</English>
+<Spanish>Always announce enemy artillery / CAS</Spanish>
+<Portuguese>Always announce enemy artillery / CAS</Portuguese>
+<Korean>Always announce enemy artillery / CAS</Korean>
+<Japanese>Always announce enemy artillery / CAS</Japanese>
+<Original>Always announce enemy artillery / CAS</Original>
+<Russian>Always announce enemy artillery / CAS</Russian>
+<Chinesesimp>Always announce enemy artillery / CAS</Chinesesimp>
+<Chinese>Always announce enemy artillery / CAS</Chinese>
+<French>Always announce enemy artillery / CAS</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1896">
 <English>Enemy AI will occupy buildings</English>
 <Spanish>La IA enemiga ocupará los edificios</Spanish>


### PR DESCRIPTION
Alert players to enemy artillery without the intel requirement.