### PR TITLE
fixed: bug was not using unique group for each civ module created

### DIFF
--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -21,47 +21,48 @@ if (isNil "d_cur_tgt_civ_modules_presenceunit") then {
 
 //create civilian module
 private _placeCivilianSpotsAndUnits = {
-	//_randomPos = [[[_trg_center, 200]],[]] call BIS_fnc_randomPos;
-	_ms1 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_civPos = _this select 0;
+	_grp = _this select 1;
+	_ms1 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,15] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms1 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms1;
 	__TRACE_1("","_ms1")
 
-	_ms2 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms2 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,15] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms2 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms2;
 	__TRACE_1("","_ms2")
 
-	_ms3 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms3 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,15] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms3 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms3;
 	__TRACE_1("","_ms3")
 
-	_ms4 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms4 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms4 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms4;
 	__TRACE_1("","_ms4")
 
-	_ms5 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms5 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms5 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms5;
 	__TRACE_1("","_ms5")
 
-	_ms6 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,50] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms6 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,50] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms6 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms6;
 	__TRACE_1("","_ms6")
 
-	_ms7 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_trg_center, [0,100] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_ms7 = _grp createUnit ["ModuleCivilianPresenceSafeSpot_F", position nearestBuilding ([[[_civPos, [0,100] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	_ms7 call _civModuleSetVars;
 	d_cur_tgt_civ_modules_presencesafespot pushBack _ms7;
 	__TRACE_1("","_ms7")
 
-	_mu1 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_mu1 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_civPos, [0,15] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	d_cur_tgt_civ_modules_presenceunit pushBack _mu1;
 	__TRACE_1("","_mu1")
 
-	_mu2 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_trg_center, [0,25] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
+	_mu2 = _grp createUnit ["ModuleCivilianPresenceUnit_F", position nearestBuilding ([[[_civPos, [0,15] call d_fnc_GetRandomRangeInt]],[]] call BIS_fnc_randomPos), [], 0, "NONE"];
 	d_cur_tgt_civ_modules_presenceunit pushBack _mu2;
 	__TRACE_1("","_mu2")
 };
@@ -89,10 +90,11 @@ for "_i" from 0 to d_civ_groupcount do {
 #ifdef __DEBUG__
 	diag_log [diag_frameno, diag_ticktime, time, format ["civilian for loop, group count _i: %1", _i]];
 #endif
+	_randomPos = [[[_trg_center, 200]],[]] call BIS_fnc_randomPos;
 	_grp = createGroup civilian;
 
 	__TRACE("Placing a civilian module...")
-	call _placeCivilianSpotsAndUnits;
+	[_randomPos, _grp] call _placeCivilianSpotsAndUnits;
 
 	private _m = _grp createUnit ["ModuleCivilianPresence_F", [0,0,0], [], 0, "NONE"];
 


### PR DESCRIPTION
This is a minor fix to the civilian module spawning.

In the future I may rewrite the code to directly create simple agent civilians.  I don't like the civilian module much... the behavior is ridiculous and they always walk around the warzone like they are on a vacation.