### PR TITLE
Ignore mikero's depbo64.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ co30_Domination.Altis.7z
 /co40_Domination.cup_chernarus_A3/*
 /co30_Domination.song_bin_tanh/*
 todo.txt
+dom_maker/DePbo64.dll


### PR DESCRIPTION
When merged, this PR will add mikero's depbo64.dll to .gitignore. This is done to keep git changes clean since dom_maker requires this file to be present but we don't want to accidently commit it to the repo.