### PR TITLE
Fix CUP BLUFOR air taxis by using different aircraft

### DIFF
--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -2494,7 +2494,7 @@ if (hasInterface) then {
 #ifdef __OWN_SIDE_BLUFOR__
 		call {
 			if (d_cup) exitWith {
-				["CUP_B_UH60M_USA", "CUP_B_MH6J_USA", "CUP_B_CH47F_USA"]
+				["CUP_B_UH60M_US", "CUP_B_MH6J_USA", "CUP_B_CH47F_USA"]
 			};
 			if (d_gmcwg) exitWith {
 				if (d_gmcwgwinter) exitWith {

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -2494,7 +2494,7 @@ if (hasInterface) then {
 #ifdef __OWN_SIDE_BLUFOR__
 		call {
 			if (d_cup) exitWith {
-				["CUP_B_MV22_USMC"]
+				["CUP_B_UH60M_USA", "CUP_B_MH6J_USA", "CUP_B_CH47F_USA"]
 			};
 			if (d_gmcwg) exitWith {
 				if (d_gmcwgwinter) exitWith {


### PR DESCRIPTION
When merged, this PR will change the CUP BLUFOR air taxi aircraft from just the MV-22 Osprey to a selection of the UH-60M Blackhawk, CH-47F Chinook, or the MH-6J Littlebird. This is done to resolve the issues with the AI landing VTOL aircraft like the Osprey - currently, the air taxi fails 9 times out of 10. 