### PR TITLE
Force streamfriendlyui

### DIFF
--- a/co30_Domination.Altis/client/fn_dfps.sqf
+++ b/co30_Domination.Altis/client/fn_dfps.sqf
@@ -2,7 +2,7 @@
 #define THIS_FILE "fn_dfps.sqf"
 #include "..\x_setup.sqf"
 
-if (!hasInterface || {isStreamFriendlyUIEnabled}) exitWith {};
+if (!hasInterface || {d_force_isstreamfriendlyui == 1 || isStreamFriendlyUIEnabled}) exitWith {};
 
 disableSerialization;
 private _disp = uiNamespace getVariable "d_fpsresource";

--- a/co30_Domination.Altis/client/x_intro.sqf
+++ b/co30_Domination.Altis/client/x_intro.sqf
@@ -193,7 +193,7 @@ xr_phd_invulnerable = false;
 uiNamespace setVariable ["D_DomLabel", nil];
 uiNamespace setVariable ["d_DomFour", nil];
 
-if (!isStreamFriendlyUIEnabled) then {
+if (!isStreamFriendlyUIEnabled && d_force_isstreamfriendlyui != 1) then {
 	0 spawn d_fnc_statusbar;
 };
 

--- a/co30_Domination.Altis/client/x_intro2.sqf
+++ b/co30_Domination.Altis/client/x_intro2.sqf
@@ -123,7 +123,7 @@ sleep 8;
 "d_introtxt1" cutText [format [localize "STR_DOM_MISSIONSTRING_1434", actionKeysNames "TeamSwitch", actionKeysNames d_3dmarker_userakey_str, actionKeysNames d_earplugs_userakey_str], "PLAIN"];
 xr_phd_invulnerable = false;
 
-if (!isStreamFriendlyUIEnabled) then {
+if (!isStreamFriendlyUIEnabled && d_force_isstreamfriendlyui != 1) then {
 	0 spawn d_fnc_statusbar;
 };
 

--- a/co30_Domination.Altis/client/x_setupplayer.sqf
+++ b/co30_Domination.Altis/client/x_setupplayer.sqf
@@ -389,7 +389,7 @@ d_points_needed_17 = (d_points_needed # 6) + 80000;
 
 	addMissionEventHandler ["Draw3D", {call d_fnc_draw3dstuff}];
 
-	if (!isStreamFriendlyUIEnabled) then {
+	if (!isStreamFriendlyUIEnabled && d_force_isstreamfriendlyui != 1) then {
 		"d_fpsresource" cutRsc ["d_fpsresource", "PLAIN"];
 		if (d_player_can_call_arti > 0 || {d_player_can_call_drop > 0 || {d_string_player in d_can_call_cas || {!d_no_ai}}}) then {
 			"d_RscSupportL" cutRsc ["d_RscSupportL", "PLAIN"];
@@ -1170,7 +1170,7 @@ if (isMultiplayer) then {
 			};
 		};
 	};
-	if (!isStreamFriendlyUIEnabled) then {
+	if (!isStreamFriendlyUIEnabled && d_force_isstreamfriendlyui != 1) then {
 		0 spawn d_fnc_statusbar;
 	};
 };

--- a/co30_Domination.Altis/clientui/fn_updatesupportrsc.sqf
+++ b/co30_Domination.Altis/clientui/fn_updatesupportrsc.sqf
@@ -3,7 +3,7 @@
 #define THIS_FILE "fn_updatesupportrsc.sqf"
 #include "..\x_setup.sqf"
 
-if (!hasInterface || {isStreamFriendlyUIEnabled}) exitWith {};
+if (!hasInterface || isStreamFriendlyUIEnabled || d_force_isstreamfriendlyui == 1) exitWith {};
 
 disableSerialization;
 

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -831,6 +831,13 @@ default = 7;
 		default = 1;
 		texts[] = {"$STR_DOM_MISSIONSTRING_363","$STR_DOM_MISSIONSTRING_1178","$STR_DOM_MISSIONSTRING_1179","$STR_DOM_MISSIONSTRING_1163"};
 	};
+	
+	class d_force_isstreamfriendlyui {
+		title = "$STR_DOM_MISSIONSTRING_1177_FORCE_NO_HUD";
+		values[] = {0,1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+	};
 
 	class d_params_dl_8 {
 		title = "$STR_DOM_MISSIONSTRING_1574";

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -7333,6 +7333,18 @@
 <Chinese>玩家標誌:</Chinese>
 <French>Marqueur joueur:</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_1177_FORCE_NO_HUD">
+<English>No HUD</English>
+<Spanish>No HUD</Spanish>
+<Portuguese>No HUD</Portuguese>
+<Korean>No HUD</Korean>
+<Japanese>No HUD</Japanese>
+<Original>No HUD</Original>
+<Russian>No HUD</Russian>
+<Chinesesimp>No HUD</Chinesesimp>
+<Chinese>No HUD</Chinese>
+<French>No HUD</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1178">
 <English>Name only</English>
 <Spanish>Sólo nombre</Spanish>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -7334,16 +7334,16 @@
 <French>Marqueur joueur:</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1177_FORCE_NO_HUD">
-<English>No HUD</English>
-<Spanish>No HUD</Spanish>
-<Portuguese>No HUD</Portuguese>
-<Korean>No HUD</Korean>
-<Japanese>No HUD</Japanese>
-<Original>No HUD</Original>
-<Russian>No HUD</Russian>
-<Chinesesimp>No HUD</Chinesesimp>
-<Chinese>No HUD</Chinese>
-<French>No HUD</French>
+<English>Force no HUD</English>
+<Spanish>Force no HUD</Spanish>
+<Portuguese>Force no HUD</Portuguese>
+<Korean>Force no HUD</Korean>
+<Japanese>Force no HUD</Japanese>
+<Original>Force no HUD</Original>
+<Russian>Force no HUD</Russian>
+<Chinesesimp>Force no HUD</Chinesesimp>
+<Chinese>Force no HUD</Chinese>
+<French>Force no HUD</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1178">
 <English>Name only</English>


### PR DESCRIPTION
Can I try to submit this again?

The client can still choose isStreamFriendly but I would like to add a parameter so the server can force that setting.  It would be nice to be able to provide a consistent user experience and many players don't know about the client setting.