### PR TITLE
fixed: incorrect logic in maintarget event selection, improved dashboard list and line breaks

### DIFF
--- a/co30_Domination.Altis/clientui/fn_statusdialoginit.sqf
+++ b/co30_Domination.Altis/clientui/fn_statusdialoginit.sqf
@@ -216,20 +216,19 @@ if (d_current_target_index != -1) then {
 			localize "STR_DOM_MISSIONSTRING_568"
 		};
 	};
-} else {
-	if (d_mt_event_messages_array isEqualTo []) then {
-		_s = localize "STR_DOM_MISSIONSTRING_568";
-	};
+	_s = format ["*** %1", _s];
 };
 
-if (!(d_mt_event_messages_array isEqualTo [])) then {
-	{
-		_s = composeText [_s, _x, '\n'];
-	} forEach d_mt_event_messages_array;
-	_s = str _s;
-};
+_s2 = "";
+{
+	_s2 = composeText [_s2, (format ["!!! %1", _x]), '\n'];
+} forEach d_mt_event_messages_array;
 
-__ctrl2(11007) ctrlSetText _s;
+_s_all = composeText [_s, _s2];
+
+_s_all = str _s_all;
+
+__ctrl2(11007) ctrlSetText _s_all;
 
 __ctrl2(12010) ctrlSetText ((player call d_fnc_GetRankPic) # 0);
 __ctrl2(11014) ctrlSetText (player call d_fnc_GetRankString);

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -671,7 +671,7 @@ if (d_with_MainTargetEvents != 0) then {
 	};
 	// choose event(s)
 	if (_doEvent) then {
-		if (d_with_MainTargetEvents == -2) then {
+		if (d_with_MainTargetEvents == -2 || {d_with_MainTargetEvents == -3}) then {
 			// create three simultaneous events		
 			_tmpMtEvents = + d_x_mt_event_types;
 			if (d_with_MainTargetEvents != -3) then {
@@ -682,6 +682,7 @@ if (d_with_MainTargetEvents != 0) then {
 			for "_i" from 0 to 2 do {
 				_tmpRandomEvent = selectRandom _tmpMtEvents;
 				[_tmpRandomEvent] call _doMainTargetEvent;
+				diag_log [format ["fooooooooooo %1", _tmpRandomEvent]];
 				_tmpMtEvents deleteAt (_tmpMtEvents find _tmpRandomEvent);
 				// if guerrilla infantry are randomly selected then there is a 1 in 3 chance of guerrilla tanks
 				if (_tmpRandomEvent == "GUERRILLA_INFANTRY" && {(random 3 <= 1)}) then {


### PR DESCRIPTION
fixed the line breaks on dashboard when events were enabled
secondary objective prefix is "***" and event objective is "!!!"