### PR TITLE
Maintarget event fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This award winning game mission stands as one of the oldest missions of the Arma
 To run the Domination mission locally:
 
 * copy the mission folder `co30_Domination.Altis` into your local `mpmission` directory
-* load the mission in Eden editor and click Play -> Multiplayer -> OK to run your local code
+* load the mission in Eden editor and click **Play** -> **Multiplayer** -> **OK** to run your local code
 
 # Editing the mission
 
@@ -22,7 +22,7 @@ The Domination mission may be modified in Eden editor.
 
 All maps supported by Domination are released as PBOs.  However you can use any PBO tool to modify and bundle your own mission modifications.  Choose `co30_Domination.Altis` as the PBO source to bundle the default map (Altis).
 
-If you want to bundle or modify maps other than Altis then follow these steps:
+If you want to bundle or modify maps other than Altis follow these steps:
 
 * delete `co30_Domination.Altis/mission.sqm`
 * copy the appropriate `mission.sqm` file from `mission_sqm` folder into `co30_Domination.Altis`

--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -313,6 +313,8 @@ class cfgFunctions {
 			addc(getbuildings);
 			addc(getcoveredpositions);
 			addc(getunitbyuid);
+			addc(sortarraybydistance);
+			addc(isvisible);
 		};
 		class Dom_ext_Scripts {
 			file = "scripts";

--- a/co30_Domination.Altis/common/fn_getbuildings.sqf
+++ b/co30_Domination.Altis/common/fn_getbuildings.sqf
@@ -7,8 +7,9 @@
 // _center - position
 // _buildingRadius - set nearestObjects radius, -1 to return only the nearest building
 // _sideHostile - (optional) side, return only buildings that are not occupied by a hostile unit
+// _minimumNumberOfPositions - (optional) return only buildings that have this many positions in the building
 
-params ["_center", "_buildingRadius", "_sideHostile"];
+params ["_center", "_buildingRadius", "_sideHostile", ["_minimumNumberOfPositions", 0, [0]]];
 
 _buildingsArray = [];
 
@@ -27,18 +28,16 @@ if (count _buildingsArray == 0) exitWith {
 
 _buildingsArrayFiltered = [];
 
-if !(isNil "_sideHostile") then {
-	{
-    	if (!((_x buildingPos -1) isEqualTo []) && {!([_x, _sideHostile] call d_fnc_isbldghostile)}) then {
-    		_buildingsArrayFiltered pushBack _x;
-    	};
-    } forEach _buildingsArray;
-} else {
-	{
-		if (!((_x buildingPos -1) isEqualTo [])) then {
-			_buildingsArrayFiltered pushBack _x;
-		};
-	} forEach _buildingsArray;
-};
-
+{
+	private _keep = true;
+	// check if bldg has enough positions available for units TODO: check if positions are already occupied!!
+	if ((_x buildingPos -1) isEqualTo []) then { _keep = false; };
+	// (optional) check if bldg has hostile units present
+	if (!isNil "_sideHostile" && {([_x, _sideHostile] call d_fnc_isbldghostile)}) then { _keep = false; };
+	// (optional) check if bldg has minimum number of positions
+	if (_minimumNumberOfPositions != 0 && {count (_x buildingPos -1) < _minimumNumberOfPositions}) then { _keep = false; };
+	if (_keep) then {
+		_buildingsArrayFiltered pushBack _x;
+	};
+} forEach _buildingsArray;
 _buildingsArrayFiltered

--- a/co30_Domination.Altis/common/fn_getbuildings.sqf
+++ b/co30_Domination.Altis/common/fn_getbuildings.sqf
@@ -30,11 +30,11 @@ _buildingsArrayFiltered = [];
 
 {
 	private _keep = true;
-	// check if bldg has enough positions available for units TODO: check if positions are already occupied!!
+	// check if bldg has any positions available for units
 	if ((_x buildingPos -1) isEqualTo []) then { _keep = false; };
 	// (optional) check if bldg has hostile units present
 	if (!isNil "_sideHostile" && {([_x, _sideHostile] call d_fnc_isbldghostile)}) then { _keep = false; };
-	// (optional) check if bldg has minimum number of positions
+	// (optional) check if bldg has minimum number of positions TODO: check if positions are already occupied!!
 	if (_minimumNumberOfPositions != 0 && {count (_x buildingPos -1) < _minimumNumberOfPositions}) then { _keep = false; };
 	if (_keep) then {
 		_buildingsArrayFiltered pushBack _x;

--- a/co30_Domination.Altis/common/fn_isinhouse.sqf
+++ b/co30_Domination.Altis/common/fn_isinhouse.sqf
@@ -5,19 +5,19 @@
 
 // check if a position is inside a house (tests if intersections isKindOf "House" in several different directions)
 
-// That line doesn't do anything
-//if (count _housePos != 3) then { false; };
-
-private _isInHouse = true;
-private _testMeHorizontalPlane = [[6,3,0], [6,-3,0], [-6,3,0], [-6,-3,0], [0,0,50]];
+private _is_in_house = true;
+private _test_vector_endpoints = [[6,3,0], [6,-3,0], [-6,3,0], [-6,-3,0], [0,0,50]];
+private _eye_height = 1.53;
+private _position_under_test_plus_eyeheight = [_this # 0, _this # 1, (_this # 2) + _eye_height];
 {
-	private _firstIntersectedItem = lineIntersectsSurfaces [
-		_this,
-		_this vectorAdd _x,
+	private _first_intersected_item = lineIntersectsSurfaces [
+		_position_under_test_plus_eyeheight,
+		_position_under_test_plus_eyeheight vectorAdd _x,
 		objNull, objNull, true, 1, "GEOM", "NONE"
 	];
-	if !(((_firstIntersectedItem # 0) select 2) isKindOf "House") then {
-		_isInHouse = false;
-	}
-} forEach _testMeHorizontalPlane;
-_isInHouse
+	private _fii = (_first_intersected_item # 0) select 2;
+	if (isNil "_fii" || {!(_fii isKindOf "House")}) exitWith {
+		_is_in_house = false;
+	};
+} forEach _test_vector_endpoints;
+_is_in_house

--- a/co30_Domination.Altis/common/fn_isvisible.sqf
+++ b/co30_Domination.Altis/common/fn_isvisible.sqf
@@ -1,0 +1,17 @@
+//by sarogahtyp edited by Longtime
+//#define __DEBUG__
+#define THIS_FILE "fn_isvisible.sqf"
+#include "..\x_setup.sqf"
+
+params ["_unit", "_target"];
+_visibleThreshold = 0.015;
+_targetEye = eyepos _target;
+_unitEye = eyepos _unit;
+
+//vector origins are half meter away from looker and target (uses 0.5 of a normalized vector which by definition is 1 meter)
+_unit_in_dir = _unitEye vectorAdd ((_unitEye vectorFromTo _targetEye) vectorMultiply 0.5);
+_target_in_dir = _targetEye vectorAdd ((_targetEye vectorFromTo _unitEye) vectorMultiply 0.5);
+
+_visiblity = parseNumber str ([objNull, "VIEW"] checkVisibility [_target_in_dir, _unit_in_dir]);
+
+(_visiblity > _visibleThreshold)

--- a/co30_Domination.Altis/common/fn_sortarraybydistance.sqf
+++ b/co30_Domination.Altis/common/fn_sortarraybydistance.sqf
@@ -1,0 +1,18 @@
+//by Jezuro edited by Longtime
+//#define __DEBUG__
+#define THIS_FILE "fn_sortarraybydistance.sqf"
+#include "..\x_setup.sqf"
+
+params ["_unitArray", "_fromPosition"];
+_unsorted = _unitArray;
+_sorted = [];
+_pos = _fromPosition;
+
+{
+	_closest = _unsorted select 0;
+	{if ((getPos _x distance _pos) < (getPos _closest distance _pos)) then {_closest = _x}} forEach _unsorted;
+	_sorted pushBack _closest;
+	_unsorted = _unsorted - [_closest]
+} forEach _unsorted;
+
+_sorted

--- a/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
@@ -18,8 +18,8 @@ if (true) exitWith {};
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
-//position the crash site near target center at max distance 250m and min 150m 
-private _poss = [[[_target_center, 250]],[[_target_center, 150]]] call BIS_fnc_randomPos;
+//position the event site near target center at max distance 125m and min 15m 
+private _poss = [[[_target_center, 125]],[[_target_center, 15]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];
 
 private _trigger = [_poss, [225,225,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -16,8 +16,8 @@ if (true) exitWith {};
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
-//position the event site near target center at max distance 250m and min 150m 
-private _poss = [[[_target_center, 250]],[[_target_center, 150]]] call BIS_fnc_randomPos;
+//position the event site near target center at max distance 125m and min 15m 
+private _poss = [[[_target_center, 125]],[[_target_center, 15]]] call BIS_fnc_randomPos;
 _x_mt_event_ar = [];
 
 private _trigger = [_poss, [225,225,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
@@ -40,7 +40,7 @@ private _allActors = [];
 
 __TRACE_1("","_prisonerGroup")
 private _nposss = [];
-_nposss = _poss findEmptyPosition [10, 25, d_sm_pilottype];
+_nposss = _poss findEmptyPosition [10, 25, d_sm_pilottype];//pilot is moved later?
 if (_nposss isEqualTo []) then {_nposss = _poss};
 private _pilot1 = _prisonerGroup createUnit [d_sm_pilottype, _nposss, [], 0, "NONE"];
 _x_mt_event_ar pushBack _pilot1;
@@ -69,7 +69,7 @@ if (d_with_dynsim == 0) then {
 
 sleep 2.333;
 
-private _enemyGuardGroup = ["specops", 1, "allmen", 0, _poss , 12, false, true, 3] call d_fnc_CreateInf select 0;
+private _enemyGuardGroup = ["specops", 1, "allmen", 0, _poss , 12, false, true, 3] call d_fnc_CreateInf select 0;//too many enemies, maybe special clothing
 {
 	[_x, 30] call d_fnc_nodamoffdyn;
 	_x forceSpeed 0;

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -34,20 +34,25 @@ private _marker = ["d_mt_event_marker_sideprisoners", _poss, "ICON","ColorBlack"
 
 private _prisonerGroup = [d_own_side] call d_fnc_creategroup;
 
-private _distance_to_rescue = 3; //in meters
+private _distance_to_rescue = 1.5; //in meters
 
 private _allActors = [];
 
 __TRACE_1("","_prisonerGroup")
+// select a starting point, units will be moved later to occupy a building if possible
 private _nposss = [];
-_nposss = _poss findEmptyPosition [10, 25, d_sm_pilottype];//pilot is moved later?
+_nposss = _poss findEmptyPosition [10, 25, d_sm_pilottype];
 if (_nposss isEqualTo []) then {_nposss = _poss};
+
+// create pilot1
 private _pilot1 = _prisonerGroup createUnit [d_sm_pilottype, _nposss, [], 0, "NONE"];
 _x_mt_event_ar pushBack _pilot1;
 _allActors pushBack _pilot1;
 [_pilot1, 30] call d_fnc_nodamoffdyn;
 __TRACE_1("","_pilot1")
 _pilot1 call d_fnc_removenvgoggles_fak;
+removeHeadgear _pilot1;
+_pilot1 unlinkItem (hmd _pilot1); //remove nvgs
 [_pilot1, getPos _pilot1] call d_fnc_setposagls;
 
 removeAllWeapons _pilot1;
@@ -69,29 +74,37 @@ if (d_with_dynsim == 0) then {
 
 sleep 2.333;
 
-private _enemyGuardGroup = ["specops", 1, "allmen", 0, _poss , 12, false, true, 3] call d_fnc_CreateInf select 0;//too many enemies, maybe special clothing
+// create 3 enemy guards with unusual hat/bandanna to help players identify them
+private _hat_type = selectRandom ["H_Cap_red", "H_Cap_blu", "H_Cap_grn"];
+private _bandanna_type = selectRandom ["G_Bandanna_beast", "G_Bandanna_shades", "G_Bandanna_sport", "G_Bandanna_aviator"];
+private _enemyGuardGroup = ["specops", 1, "allmen", 0, _nposss , 5, false, true, 3] call d_fnc_CreateInf select 0;
 {
 	[_x, 30] call d_fnc_nodamoffdyn;
 	_x forceSpeed 0;
+	_x unlinkItem (hmd _x); //remove nvgs
+	removeHeadgear _x;
+	_x addHeadgear _hat_type;
+	_x addGoggles _bandanna_type;
 	_allActors pushBack _x;
 	_x_mt_event_ar pushBack _x;
 } forEach (units _enemyGuardGroup);
 
-//occupy a building using Zenophon script
-_unitsNotGarrisoned = [
-	_poss,											// Params: 1. Array, the building(s) nearest this position is used
-	_allActors,									//         2. Array of objects, the units that will garrison the building(s)
-	-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
-	false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
-	false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
-	true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
-	false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
-	2,   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
-	true,                                                //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead
-	true                                                //  (opt.) 10. Boolean, true to allow the selected position to be near an enemy (default: false)
-] call d_fnc_Zen_OccupyHouse;
+//find a suitable building and occupy
+_buildings_array_sorted_by_distance = [[_poss, 200, nil, (count _allActors)] call d_fnc_getbuildings, _poss] call d_fnc_sortarraybydistance;
+private _unitsNotGarrisoned = [];
+{
+	//dry run to find a suitable building
+	_unitsNotGarrisoned = [getPos _x, _allActors, -1, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse;
+	if (count _unitsNotGarrisoned == 0) exitWith {
+		// building is suitable
+		_unitsNotGarrisoned = [getPos _x, _allActors, -1, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
+	};
 
-{deleteVehicle _x} forEach _unitsNotGarrisoned;
+} forEach _buildings_array_sorted_by_distance;
+
+{
+	//diag_log [format ["failed to garrison and will remain in starting position: %1", _x]];
+} forEach _unitsNotGarrisoned;
 
 private _all_dead = false;
 private _isExecutePrisoners = false;
@@ -108,30 +121,22 @@ while {!d_mt_done} do {
 	};
 	
 	if ((units _enemyGuardGroup) findIf {damage _x > 0.02} != -1) then {
-		//if any unit in enemyGuardGroup is wounded more than 0.15 then set flag to shoot prisoners
-    	_isExecutePrisoners = true;
-	};
-    
-    if (_isExecutePrisoners) then {
+		//a unit in enemyGuardGroup was wounded, soon guards will shoot prisoner and a bomb will explode
 		_pilot1 setCaptive false;
-		{
-        	_x forceSpeed -1;
-        } forEach (units _enemyGuardGroup);
-    };
-    
-    if (_isExecutePrisoners || {!(captive _pilot1)}) then {
+		// brief delay until the guards attempt to execute the prisoner
+		sleep 2;
 		{	
 			//todo - play a sound?
 			_x forceSpeed -1;
-			_enemyGuardGroup reveal [_pilot1, 4];
-			_x doTarget _pilot1;
-			_x doSuppressiveFire _pilot1;
 		} forEach (units _enemyGuardGroup);
-    };
-    
-    // gimme three steps mister
-    if (_isExecutePrisoners) then {
-		sleep 3;
+		// another brief delay, players must kill all guards or an explosion will occur
+		sleep 5;
+		if (({alive _x} count units _enemyGuardGroup) > 0) then {
+			// not all of the guards were killed so a suicide bomb is triggered
+			_bomb_type = "Rocket_04_HE_F"; //TODO: bigger??
+			_bomb = _bomb_type createVehicle [0,0,5000];
+			_bomb setPosASL eyePos _pilot1;
+        };
 	};
 	
 	sleep 3.14;

--- a/co30_Domination.Altis/missions/fn_createinf.sqf
+++ b/co30_Domination.Altis/missions/fn_createinf.sqf
@@ -25,7 +25,7 @@ if (isNil "_pos_center") exitWith {
 	diag_log ["fn_createinf.sqf _this: ", _this];
 };
 private _radius = _this select 5;
-private _do_patrol = if (_radius < 50) then {false} else {if (count _this == 7) then {_this select 6} else {false}};
+private _do_patrol = if (_radius < 50) then {false} else {if (count _this > 6) then {_this select 6} else {false}};
 private _ret_grps = [];
 private _isArmorAdjustmentDisabled = if (count _this > 7) then {_this select 7} else {false};
 private _unitsPerGroup = if (count _this > 8) then {_this select 8} else {-1};

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -25,6 +25,7 @@
 //                2 - unit is static, no movement allowed
 //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead
 //  (opt.) 10. Boolean, true to allow the selected position to be near an enemy (default: false)
+//  (opt.) 11. Boolean, true to dry run, for testing only no units are moved, still returns array of units that could not be garrisoned at given pos (default: false)
 // Return: Array of objects, the units that were not garrisoned
 
 #define I(X) X = X + 1;
@@ -45,7 +46,8 @@ params [
 	["_doMove", false, [true]],
 	["_unitMovementMode", 0, [0]],
 	["_isRequireRoofOverhead", false, [true]],
-	["_isAllowSpawnNearEnemy", false, [true]]
+	["_isAllowSpawnNearEnemy", false, [true]],
+	["_isDryRun", false, [true]]
 ];
 
 private [
@@ -171,7 +173,11 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 		_posArray deleteAt 0;
 		_housePos = [_housePosArray select 0, _housePosArray select 1, (_housePosArray select 2) + (getTerrainHeightASL _housePosArray) + EYE_HEIGHT];
 		
-		if (_isRequireRoofOverhead && {!((_housePos) call d_fnc_isinhouse)}) exitWith {};
+		if (_isRequireRoofOverhead) then {
+			if (!((_housePos) call d_fnc_isinhouse)) exitWith {
+				// the position is not inside a house
+			};
+		};
 
 		_startAngle = (round random 10) * (round random 36);
 		for "_i" from _startAngle to (_startAngle + 350) step 10 do {
@@ -206,79 +212,80 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 							};
 
 							if (!_isRoof || {_edge}) then {
-								private _uuidx = _units select _unitIndex;
-								_uuidx doWatch ([_housePos, CHECK_DISTANCE, 90 - _i, (_housePos select 2) - (getTerrainHeightASL _housePos)] call _Zen_ExtendPosition);
-
-								if (_doMove) then {
-									_uuidx doMove ASLToATL ([_housePos select 0, _housePos select 1, (_housePos select 2) - EYE_HEIGHT]);
-								} else {
-									_uuidx setPosASL [_housePos select 0, _housePos select 1, (_housePos select 2) - EYE_HEIGHT];
-									_uuidx setDir _i;
-
-									doStop _uuidx;
-								};
-
-								//occupy mode - no special behavior
-								if (_unitMovementMode == 0) then {
-									//do nothing
-								};
-
-								//ambush mode - static until firedNear within 69m restores unit ability to move and fire
-								if (_unitMovementMode == 1) then {
-
-									if !(_doMove) then {
-										_uuidx disableAI "TARGET";
-										_uuidx forceSpeed 0;
-									};
-
-									_uuidx setVariable ["zen_fn_idx2", _uuidx addEventHandler ["FiredNear", {
-										params ["_unit", "_firer", "_distance", "_weapon", "_muzzle", "_mode", "_ammo", "_gunner"];
-										scriptName "spawn_zoh_firednear1ambush";
-										if (d_side_player getFriend side (group _firer) >= 0.6) then {
-											(_this select 0) enableAI "TARGET";
-											(_this select 0) enableAI "AUTOTARGET";
-											(_this select 0) enableAI "MOVE";
-											(_this select 0) forceSpeed -1;
-										};
-									}]];
-								};
-
-								//sniper mode - static forever
-								if (_unitMovementMode == 2) then {
-									if (d_snp_aware == 1) then {
-										//highly aware snipers
-										//do nothing, advanced awareness is already loaded with d_fnc_hallyg_dlegion_Snipe_awareness
+								if (!_isDryRun) then {
+									private _uuidx = _units select _unitIndex;
+									_uuidx doWatch ([_housePos, CHECK_DISTANCE, 90 - _i, (_housePos select 2) - (getTerrainHeightASL _housePos)] call _Zen_ExtendPosition);
+								
+									if (_doMove) then {
+										_uuidx doMove ASLToATL ([_housePos select 0, _housePos select 1, (_housePos select 2) - EYE_HEIGHT]);
 									} else {
-										//common snipers with up/down script triggered by firedNear within 69m but no advanced awareness
-										if (_isRoof) then {
-											_uuidx setUnitPos "MIDDLE";
-											_uuidx setVariable ["zen_fn_idx", _uuidx addEventHandler ["FiredNear", {
-												scriptName "spawn_zoh_firednear1";
-												[_this select 0, ["DOWN","MIDDLE"]] spawn d_fnc_Zen_JBOY_UpDown;
-											}]];
-										} else {
-											_uuidx setUnitPos "UP";
-											_uuidx setVariable ["zen_fn_idx",_uuidx addEventHandler ["FiredNear", {
-												scriptName "spawn_zoh_firednear2";
-												[_this select 0, ["UP","MIDDLE"]] spawn d_fnc_Zen_JBOY_UpDown;
-											}]];
+										_uuidx setPosASL [_housePos select 0, _housePos select 1, (_housePos select 2) - EYE_HEIGHT];
+										_uuidx setDir _i;
+	
+										doStop _uuidx;
+									};
+	
+									//occupy mode - no special behavior
+									if (_unitMovementMode == 0) then {
+										//do nothing
+									};
+	
+									//ambush mode - static until firedNear within 69m restores unit ability to move and fire
+									if (_unitMovementMode == 1) then {
+	
+										if !(_doMove) then {
+											_uuidx disableAI "TARGET";
+											_uuidx forceSpeed 0;
 										};
-
+	
+										_uuidx setVariable ["zen_fn_idx2", _uuidx addEventHandler ["FiredNear", {
+											params ["_unit", "_firer", "_distance", "_weapon", "_muzzle", "_mode", "_ammo", "_gunner"];
+											scriptName "spawn_zoh_firednear1ambush";
+											if (d_side_player getFriend side (group _firer) >= 0.6) then {
+												(_this select 0) enableAI "TARGET";
+												(_this select 0) enableAI "AUTOTARGET";
+												(_this select 0) enableAI "MOVE";
+												(_this select 0) forceSpeed -1;
+											};
+										}]];
+									};
+	
+									//sniper mode - static forever
+									if (_unitMovementMode == 2) then {
+										if (d_snp_aware == 1) then {
+											//highly aware snipers
+											//do nothing, advanced awareness is already loaded with d_fnc_hallyg_dlegion_Snipe_awareness
+										} else {
+											//common snipers with up/down script triggered by firedNear within 69m but no advanced awareness
+											if (_isRoof) then {
+												_uuidx setUnitPos "MIDDLE";
+												_uuidx setVariable ["zen_fn_idx", _uuidx addEventHandler ["FiredNear", {
+													scriptName "spawn_zoh_firednear1";
+													[_this select 0, ["DOWN","MIDDLE"]] spawn d_fnc_Zen_JBOY_UpDown;
+												}]];
+											} else {
+												_uuidx setUnitPos "UP";
+												_uuidx setVariable ["zen_fn_idx",_uuidx addEventHandler ["FiredNear", {
+													scriptName "spawn_zoh_firednear2";
+													[_this select 0, ["UP","MIDDLE"]] spawn d_fnc_Zen_JBOY_UpDown;
+												}]];
+											};
+	
+											if !(_doMove) then {
+												_uuidx disableAI "TARGET";
+												_uuidx forceSpeed 0;
+											};
+										};
+									};
+									
+									//overwatch mode - static forever but without special sniper behaviors
+									if (_unitMovementMode == 3) then {
 										if !(_doMove) then {
 											_uuidx disableAI "TARGET";
 											_uuidx forceSpeed 0;
 										};
 									};
-								};
-								
-								//overwatch mode - static forever but without special sniper behaviors
-								if (_unitMovementMode == 3) then {
-									if !(_doMove) then {
-										_uuidx disableAI "TARGET";
-										_uuidx forceSpeed 0;
-									};
-								};
-
+								};//end if _isDryRun
 								I(_unitIndex)
 								if (_fillEvenly) then {
 									breakTo "for";

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
@@ -27,39 +27,6 @@ private _isLOS = {
 	};
 };
 
-//by Jezuro
-private _sortArrayByDistance = {
-	params ["_unitArray", "_fromPosition"];
-	_unsorted = _unitArray;
-	_sorted = [];
-	_pos = _fromPosition;
-
-	{
-		_closest = _unsorted select 0;
-		{if ((getPos _x distance _pos) < (getPos _closest distance _pos)) then {_closest = _x}} forEach _unsorted;
-		_sorted pushBack _closest;
-		_unsorted = _unsorted - [_closest]
-	} forEach _unsorted;
-
-	_sorted
-};
-
-//by sarogahtyp
-private _isVisible = {
-	params ["_unit", "_target"];
-	_visibleThreshold = 0.015;
-	_targetEye = eyepos _target;
-	_unitEye = eyepos _unit;
-
-	//vector origins are half meter away from looker and target (uses 0.5 of a normalized vector which by definition is 1 meter)
-	_unit_in_dir = _unitEye vectorAdd ((_unitEye vectorFromTo _targetEye) vectorMultiply 0.5);
-	_target_in_dir = _targetEye vectorAdd ((_targetEye vectorFromTo _unitEye) vectorMultiply 0.5);
-
-	_visiblity = parseNumber str ([objNull, "VIEW"] checkVisibility [_target_in_dir, _unit_in_dir]);
-
-	(_visiblity > _visibleThreshold)
-};
-
 //_unit disableAI "AIMINGERROR";
 _unit disableAI "TARGET";
 
@@ -95,12 +62,12 @@ while {true} do {
 	_fired = false;
 	
 	if (count _Dtargets > 0) then {
-		_playersSortedByDistance = [_Dtargets, getPos _unit] call _sortArrayByDistance;
+		_playersSortedByDistance = [_Dtargets, getPos _unit] call d_fnc_sortarraybydistance;
 		
 		if (_isAggressiveShoot == 1) then {
 			{
 				if (!alive _unit) exitWith {};
-				if (([_unit, _x] call _isVisible) || {[_unit, _x, 360] call _isLOS}) then {
+				if (([_unit, _x] call d_fnc_isvisible) || {[_unit, _x, 360] call _isLOS}) then {
 					//to check if unit actually fired
 					_ammoCount = _unit ammo primaryWeapon _unit;
 					_magazineCount = count magazinesAmmo _unit; 

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -682,7 +682,6 @@ if (d_with_MainTargetEvents != 0) then {
 			for "_i" from 0 to 2 do {
 				_tmpRandomEvent = selectRandom _tmpMtEvents;
 				[_tmpRandomEvent] call _doMainTargetEvent;
-				diag_log [format ["fooooooooooo %1", _tmpRandomEvent]];
 				_tmpMtEvents deleteAt (_tmpMtEvents find _tmpRandomEvent);
 				// if guerrilla infantry are randomly selected then there is a 1 in 3 chance of guerrilla tanks
 				if (_tmpRandomEvent == "GUERRILLA_INFANTRY" && {(random 3 <= 1)}) then {

--- a/co30_Domination.Altis/server/fn_makemgroup.sqf
+++ b/co30_Domination.Altis/server/fn_makemgroup.sqf
@@ -28,7 +28,7 @@ __TRACE_2("","_mchelper","_doreduce")
 
 private _ret = [];
 
-if (d_smallgrps == 0 && {_doreduce}) then {
+if ((d_smallgrps == 0 && {_doreduce}) || _unitsPerGroup > 0) then {
 	_unitliste = [_unitliste, _unitsPerGroup] call d_fnc_ulreduce;
 };
 


### PR DESCRIPTION
* added a "dry run" parameter to the occupy script so we can test if a building has the required filtered positions before moving any units
* extracted some helper functions
* prisoner rescue event now has a suicide bomb
* prison guards now wear unusual headgear to help players identify them