### PR TITLE
fixed: whitelisted weather and skip time functions required for the respective zeus modules to work

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -212,6 +212,9 @@ class CfgRemoteExec {
 		class d_fnc_remactionssm {allowedTargets = 1;};
 		class d_fnc_addpushaction {allowedTargets = 1;};
 		class d_fnc_initPlayerServer {allowedTargets = 2;};
+		class bis_fnc_setfog {allowedTargets = 2;};
+		class bis_fnc_setovercast {allowedTargets = 2;};
+		class bis_fnc_setdate {allowedTargets = 2;};
 #ifdef __TT__
 		class d_fnc_addpoints {allowedTargets = 2;};
 		class d_fnc_addsmpoints {allowedTargets = 2;};


### PR DESCRIPTION
now the weather and time modules work in zeus with strict cfgremoteexec security