### PR TITLE
spawn on squad leader or squad member

### DIFF
--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -67,6 +67,7 @@ class cfgFunctions {
 			addc(sethud);
 			addc(vecdialog);
 			addc(showdynamicgroupsdialog);
+			addc(iseligibletospawnnewunit);
 			addc(heli_action);
 			addc(heli_release);
 			addc(bike);

--- a/co30_Domination.Altis/client/fn_iseligibletospawnnewunit.sqf
+++ b/co30_Domination.Altis/client/fn_iseligibletospawnnewunit.sqf
@@ -1,0 +1,16 @@
+// by Longtime
+//#define __DEBUG__
+#include "..\x_setup.sqf"
+
+//check if _unit (a player) is eligible for another player to spawn on them
+//if _unit is alive, conscious, not falling, not swimming and if in a vehicle has cargo space available for the new player
+
+params ["_unit"];
+
+private _emptycargo = [0, (vehicle _unit) emptyPositions "cargo"] select (!isNull objectParent _unit);
+
+if (alive _unit && {!(_unit getVariable ["xr_pluncon", false])} && {!(_unit getVariable ["ace_isunconscious", false])} && {_emptycargo > 0 || {(getPos _unit) # 2 < 10}} && {!(_unit call d_fnc_isswimming)} && {!underwater _unit}) then {
+	true
+} else {
+	false
+}

--- a/co30_Domination.Altis/clientui/fn_respawn_mar_anim.sqf
+++ b/co30_Domination.Altis/clientui/fn_respawn_mar_anim.sqf
@@ -31,7 +31,6 @@ while {!isNil "d_teleport_off" && {(xr_max_lives != -1 && {player getVariable ["
 		_old_respmar setMarkerDirLocal _cur_ang;
 	};
 	if (_has_sql == 1) then {
-		//private _lpos = nil;
 		private _lpos = visiblePositionASL (leader (group player)); // assume squad leader
 		if (!([leader (group player)] call d_fnc_iseligibletospawnnewunit)) then {
 			{

--- a/co30_Domination.Altis/clientui/fn_respawn_mar_anim.sqf
+++ b/co30_Domination.Altis/clientui/fn_respawn_mar_anim.sqf
@@ -31,9 +31,17 @@ while {!isNil "d_teleport_off" && {(xr_max_lives != -1 && {player getVariable ["
 		_old_respmar setMarkerDirLocal _cur_ang;
 	};
 	if (_has_sql == 1) then {
-		private _lpos = visiblePositionASL (leader (group player));
+		//private _lpos = nil;
+		private _lpos = visiblePositionASL (leader (group player)); // assume squad leader
+		if (!([leader (group player)] call d_fnc_iseligibletospawnnewunit)) then {
+			{
+				if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
+					_lpos = visiblePositionASL _x;
+				};
+			} forEach (units group player);
+		};
 		"D_SQL_D" setMarkerPosLocal _lpos;
-		if (!isNil "d_respawn_posis") then {
+		if (!isNil "d_respawn_posis" && !isNil "d_resp_lead_idx") then {
 			d_respawn_posis set [d_resp_lead_idx, _lpos];
 		};
 	};

--- a/co30_Domination.Altis/clientui/fn_teleportdialoginit.sqf
+++ b/co30_Domination.Altis/clientui/fn_teleportdialoginit.sqf
@@ -162,7 +162,6 @@ if (d_respawnatsql == 2 || {!(player getVariable ["xr_isleader", false]) && {cou
 };
 
 private _respawn_target = nil;
-private _is_eligible_to_respawn = false;
 if (_show_respawnatsql) then {
 	_cidx = _listctrl lbAdd (localize "STR_DOM_MISSIONSTRING_1705a");
 	_listctrl lbSetData [_cidx, "D_SQL_D"];
@@ -170,19 +169,17 @@ if (_show_respawnatsql) then {
 	if (leader (group player) != player && [leader (group player)] call d_fnc_iseligibletospawnnewunit) then {
 		// the squad leader is eligible as a spawn target
 		_respawn_target = leader (group player);
-		_is_eligible_to_respawn = true;
 	};
-	if (!_is_eligible_to_respawn && d_respawnatsql == 2) then {
+	if (isNil "_respawn_target" && d_respawnatsql == 2) then {
 		// d_respawnatsql == 2 allows respawn on squadmates
 		// are any squadmates alive and eligible as a spawn target?
 		{
 			if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
-				_is_eligible_to_respawn = true;
 				_respawn_target = _x;
 			};
 		} forEach (units group player);
 	};
-	private _lbcolor = if (_is_eligible_to_respawn) then {
+	private _lbcolor = if (!isNil "_respawn_target") then {
 		[1,1,1,1.0]
 	} else {
 		_logtxt = localize "STR_DOM_MISSIONSTRING_1706";

--- a/co30_Domination.Altis/clientui/fn_teleportdialoginit.sqf
+++ b/co30_Domination.Altis/clientui/fn_teleportdialoginit.sqf
@@ -155,13 +155,34 @@ private _logtxt = "";
 private _has_sql = 0;
 d_resp_lead_idx = -1;
 
-if (d_respawnatsql == 0 && {!(player getVariable ["xr_isleader", false]) && {count units (group player) > 1 && {player != leader (group player)}}}) then {
+private _show_respawnatsql = false;
+if (d_respawnatsql == 2 || {!(player getVariable ["xr_isleader", false]) && {count units (group player) > 1 && {player != leader (group player)}}}) then {
+	// d_respawnatsql == 2 always show respawn button, determine color later
+	_show_respawnatsql = true;
+};
+
+private _respawn_target = nil;
+private _is_eligible_to_respawn = false;
+if (_show_respawnatsql) then {
 	_cidx = _listctrl lbAdd (localize "STR_DOM_MISSIONSTRING_1705a");
 	_listctrl lbSetData [_cidx, "D_SQL_D"];
 	_has_sql = 1;
-	private _leader = leader (group player);
-	private _emptycargo = [0, (vehicle _leader) emptyPositions "cargo"] select (!isNull objectParent _leader);
-	private _lbcolor = if (alive _leader && {!(_leader getVariable ["xr_pluncon", false])} && {!(_leader getVariable ["ace_isunconscious", false])} && {_emptycargo > 0 || {(getPos _leader) # 2 < 10}} && {!(_leader call d_fnc_isswimming)} && {!underwater _leader}) then {
+	if (leader (group player) != player && [leader (group player)] call d_fnc_iseligibletospawnnewunit) then {
+		// the squad leader is eligible as a spawn target
+		_respawn_target = leader (group player);
+		_is_eligible_to_respawn = true;
+	};
+	if (!_is_eligible_to_respawn && d_respawnatsql == 2) then {
+		// d_respawnatsql == 2 allows respawn on squadmates
+		// are any squadmates alive and eligible as a spawn target?
+		{
+			if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
+				_is_eligible_to_respawn = true;
+				_respawn_target = _x;
+			};
+		} forEach (units group player);
+	};
+	private _lbcolor = if (_is_eligible_to_respawn) then {
 		[1,1,1,1.0]
 	} else {
 		_logtxt = localize "STR_DOM_MISSIONSTRING_1706";
@@ -179,9 +200,9 @@ if (d_respawnatsql == 0 && {!(player getVariable ["xr_isleader", false]) && {cou
 		};
 		__CTRL(100110) ctrlSetText _text;
 	};
-	["D_SQL_D", visiblePositionASL _leader, "ICON", "ColorWhite", [1.5,1.5], "", 0, "selector_selectedMission"] call d_fnc_CreateMarkerLocal;
+	["D_SQL_D", visiblePositionASL _respawn_target, "ICON", "ColorWhite", [1.5,1.5], "", 0, "selector_selectedMission"] call d_fnc_CreateMarkerLocal;
 	d_respawn_anim_markers pushBack "D_SQL_D";
-	d_resp_lead_idx = d_respawn_posis pushBack (visiblePositionASL _leader);
+	d_resp_lead_idx = d_respawn_posis pushBack (visiblePositionASL _respawn_target);
 	d_respawn_ismhq pushBack false;
 };
 

--- a/co30_Domination.Altis/clientui/fn_teleupdate_dlg.sqf
+++ b/co30_Domination.Altis/clientui/fn_teleupdate_dlg.sqf
@@ -20,6 +20,8 @@ private _listctrl = __CTRL(1500);
 
 #define __COLRED [1,0,0,0.7]
 
+private _respawn_target = nil;
+private _is_eligible_to_respawn = false;
 for "_i" from 0 to ((lbSize _listctrl) - 1) do {
 	private _lbdata = _listctrl lbData _i;
 	__TRACE_1("","_lbdata")
@@ -64,31 +66,45 @@ for "_i" from 0 to ((lbSize _listctrl) - 1) do {
 					};
 				};
 			} else {
-				if (d_respawnatsql == 0 && {_lbdata == "D_SQL_D" && {!(player getVariable ["xr_isleader", false]) && {count units (group player) > 1 && {player != leader (group player)}}}}) then {
-					private _leader = leader (group player);
-					private _leadavail = false;
-					private _emptycargo = [0, (vehicle _leader) emptyPositions "cargo"] select (!isNull objectParent _leader);
-					private _lbcolor = if (xr_respawn_available && {alive _leader} && {!(_leader getVariable ["xr_pluncon", false])} && {!(_leader getVariable ["ace_isunconscious", false])} && {_emptycargo > 0 || {(getPos _leader) # 2 < 10}} && {!(_leader call d_fnc_isswimming)} && {!underwater _leader}) then {
-						_leadavail = true;
-						[1,1,1,1.0]
-					} else {
-						__COLRED
-					};
-					_listctrl lbSetColor [_i, _lbcolor];
-					if (lbCurSel _listctrl == _i) then {
-						if (_leadavail) then {
-							private _text = if (_wone == 1 || {d_tele_dialog == 0}) then {
-							format [localize "STR_DOM_MISSIONSTRING_607", localize "STR_DOM_MISSIONSTRING_1705a"]
-							} else {
-								format [localize "STR_DOM_MISSIONSTRING_605", localize "STR_DOM_MISSIONSTRING_1705a"]
-							};
-							__CTRL(100102) ctrlEnable true;
-							__TRACE_1("SQL enable true","_lbdata")
-							__CTRL(100110) ctrlSetText _text;
+				if (d_respawnatsql in [0,2] && _lbdata == "D_SQL_D") then {
+					// d_respawnatsql == 2 always show button, otherwise only show if isleader == false (a squadmate)
+					if (d_respawnatsql == 2 || !(player getVariable ["xr_isleader", false])) then {
+						if (leader (group player) != player && [leader (group player)] call d_fnc_iseligibletospawnnewunit) then {
+							// the squad leader is eligible as a spawn target
+							_respawn_target = leader (group player);
+							_is_eligible_to_respawn = true;
+						};
+						if (!_is_eligible_to_respawn && d_respawnatsql == 2) then {
+							// d_respawnatsql == 2 allows respawn on squadmates
+							// are any squadmates alive and eligible as a spawn target?
+							{
+								if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
+									_is_eligible_to_respawn = true;
+									_respawn_target = _x;
+								};
+							} forEach (units group player);
+						};
+						private _lbcolor = if (_is_eligible_to_respawn) then {
+							[1,1,1,1.0]
 						} else {
-							__CTRL(100102) ctrlEnable false;
-							__TRACE_1("SQL enable false","_lbdata")
-							__CTRL(100110) ctrlSetText "";
+							__COLRED
+						};
+						_listctrl lbSetColor [_i, _lbcolor];
+						if (lbCurSel _listctrl == _i) then {
+							if (_is_eligible_to_respawn) then {
+								private _text = if (_wone == 1 || {d_tele_dialog == 0}) then {
+								format [localize "STR_DOM_MISSIONSTRING_607", localize "STR_DOM_MISSIONSTRING_1705a"]
+								} else {
+									format [localize "STR_DOM_MISSIONSTRING_605", localize "STR_DOM_MISSIONSTRING_1705a"]
+								};
+								__CTRL(100102) ctrlEnable true;
+								__TRACE_1("SQL enable true","_lbdata")
+								__CTRL(100110) ctrlSetText _text;
+							} else {
+								__CTRL(100102) ctrlEnable false;
+								__TRACE_1("SQL enable false","_lbdata")
+								__CTRL(100110) ctrlSetText "";
+							};
 						};
 					};
 				};

--- a/co30_Domination.Altis/clientui/fn_teleupdate_dlg.sqf
+++ b/co30_Domination.Altis/clientui/fn_teleupdate_dlg.sqf
@@ -21,7 +21,6 @@ private _listctrl = __CTRL(1500);
 #define __COLRED [1,0,0,0.7]
 
 private _respawn_target = nil;
-private _is_eligible_to_respawn = false;
 for "_i" from 0 to ((lbSize _listctrl) - 1) do {
 	private _lbdata = _listctrl lbData _i;
 	__TRACE_1("","_lbdata")
@@ -72,26 +71,24 @@ for "_i" from 0 to ((lbSize _listctrl) - 1) do {
 						if (leader (group player) != player && [leader (group player)] call d_fnc_iseligibletospawnnewunit) then {
 							// the squad leader is eligible as a spawn target
 							_respawn_target = leader (group player);
-							_is_eligible_to_respawn = true;
 						};
-						if (!_is_eligible_to_respawn && d_respawnatsql == 2) then {
+						if (isNil "_respawn_target" && d_respawnatsql == 2) then {
 							// d_respawnatsql == 2 allows respawn on squadmates
 							// are any squadmates alive and eligible as a spawn target?
 							{
 								if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
-									_is_eligible_to_respawn = true;
 									_respawn_target = _x;
 								};
 							} forEach (units group player);
 						};
-						private _lbcolor = if (_is_eligible_to_respawn) then {
+						private _lbcolor = if (!isNil "_respawn_target") then {
 							[1,1,1,1.0]
 						} else {
 							__COLRED
 						};
 						_listctrl lbSetColor [_i, _lbcolor];
 						if (lbCurSel _listctrl == _i) then {
-							if (_is_eligible_to_respawn) then {
+							if (!isNil "_respawn_target") then {
 								private _text = if (_wone == 1 || {d_tele_dialog == 0}) then {
 								format [localize "STR_DOM_MISSIONSTRING_607", localize "STR_DOM_MISSIONSTRING_1705a"]
 								} else {

--- a/co30_Domination.Altis/clientui/fn_update_telerespsel.sqf
+++ b/co30_Domination.Altis/clientui/fn_update_telerespsel.sqf
@@ -22,7 +22,6 @@ __TRACE_1("","_data")
 
 #define __COLRED [1,0,0,0.7]
 private _mravailable = false;
-private _is_eligible_to_respawn = false;
 private _respawn_target = nil;
 private _not_avail_array = [];
 private _disp = [uiNamespace getVariable "XR_SpectDlg", uiNamespace getVariable "d_TeleportDialog"] select (_wone == 0);
@@ -64,19 +63,17 @@ if (_uidx == -1) then {
 				if (leader (group player) != player && [leader (group player)] call d_fnc_iseligibletospawnnewunit) then {
 					// the squad leader is eligible as a spawn target
 					_respawn_target = leader (group player);
-					_is_eligible_to_respawn = true;
 				};
-				if (!_is_eligible_to_respawn && d_respawnatsql == 2) then {
+				if (isNil "_respawn_target" && d_respawnatsql == 2) then {
 					// d_respawnatsql == 2 allows respawn on squadmates
 					// are any squadmates alive and eligible as a spawn target?
 					{
 						if (_x != player && [_x] call d_fnc_iseligibletospawnnewunit) exitWith {
-							_is_eligible_to_respawn = true;
 							_respawn_target = _x;
 						};
 					} forEach (units group player);
 				};
-				private _lbcolor = if (_is_eligible_to_respawn) then {
+				private _lbcolor = if (!isNil "_respawn_target") then {
 					[1,1,1,1.0]
 				} else {
 					_not_avail_array pushBack "D_SQL_D";
@@ -130,11 +127,10 @@ if (_wone == 1 && {!xr_respawn_available}) then {
 };
 
 __TRACE_3("","_data","_mravailable","_uidx")
-__TRACE_1("","_is_eligible_to_respawn")
 __TRACE_1("","xr_respawn_available")
 __TRACE_1("","_not_avail_array")
 
-if (_data != "" && {_mravailable || {_data == "D_BASE_D" || {_is_eligible_to_respawn || {_uidx != -1}}}}) then {
+if (_data != "" && {_mravailable || {_data == "D_BASE_D" || {!isNil "_respawn_target" || {_uidx != -1}}}}) then {
 	d_beam_target = _data;
 	private _text = if (_wone == 1 || {d_tele_dialog == 0}) then {
 		format [localize "STR_DOM_MISSIONSTRING_607", _ctrl lbText _sel]

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -453,6 +453,13 @@ class Params {
 		texts[] = {"$STR_DOM_MISSIONSTRING_1053","$STR_DOM_MISSIONSTRING_1054","$STR_DOM_MISSIONSTRING_1055"};
 	};
 	
+	class d_respawnatsql {
+		title = "$STR_DOM_MISSIONSTRING_1705";
+		values[] = {0,2,1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1705a","$STR_DOM_MISSIONSTRING_SQUAD","$STR_DOM_MISSIONSTRING_405"};
+	};
+	
 	class d_retakefarps {
 		title = "$STR_DOM_MISSIONSTRING_2036";
 		values[] = {0,1};
@@ -1348,13 +1355,6 @@ class Params {
 		values[] = {0,1};
 		default = 0;
 		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
-	};
-
-	class d_respawnatsql {
-		title = "$STR_DOM_MISSIONSTRING_1705";
-		values[] = {0,1,2};
-		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_1705a","$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_SQUAD"};
 	};
 
 	class d_params_dl_11 {

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -1352,9 +1352,9 @@ class Params {
 
 	class d_respawnatsql {
 		title = "$STR_DOM_MISSIONSTRING_1705";
-		values[] = {0,1};
+		values[] = {0,1,2};
 		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_1705a","$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_SQUAD"};
 	};
 
 	class d_params_dl_11 {

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10344,6 +10344,18 @@
 <Chinese>小隊長</Chinese>
 <French>Chef d'Équipe</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_SQUAD">
+<English>Squad</English>
+<Spanish>Escuadrón</Spanish>
+<Portuguese>Equipe</Portuguese>
+<Korean>Squad</Korean>
+<Japanese>Squad</Japanese>
+<Original>Squad</Original>
+<Russian>Squad</Russian>
+<Chinesesimp>Squad</Chinesesimp>
+<Chinese>Squad</Chinese>
+<French>Équipe</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1706">
 <English>Respawn at Leader not available</English>
 <Spanish>Reaparecer en el líder no disponible</Spanish>


### PR DESCRIPTION
added: new selection for d_respawnatsql allows players to spawn on squad leader or any living squad member, iseligibletospawnnewunit long name but useful utility function

Tested on MP with two separate machines.  Respawn button enabled for the Squad leader if any squad member is alive.  Helps avoid the entire team being wiped out.