### PR TITLE
default value for auto viewdistance

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -796,6 +796,17 @@ class Params {
 		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
 	};
 	
+	class d_AutoViewdistanceChangeDefault {
+		title = "$STR_DOM_MISSIONSTRING_1964";
+		values[] = {0,1};
+#ifdef __TT__
+		default = 0;
+#else
+		default = 1;
+#endif
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+	};
+	
 	class d_playerspectateatbase {
 		title = "$STR_DOM_MISSIONSTRING_2057";
 		values[] = {0,1};

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -2752,12 +2752,12 @@ if (hasInterface) then {
 	d_add_resp_points_pos = [];
 
 	d_earplugs_fitted = false;
-#ifndef __TT__
-	d_maintarget_auto_vd = true;
-#else
-	d_maintarget_auto_vd = false;
-#endif
 
+	if (d_AutoViewdistanceChangeDefault == 1) then {
+		d_maintarget_auto_vd = true;
+	} else {
+		d_maintarget_auto_vd = false;
+	};
 	d_deploy_mhq_camo = true;
 
 	d_player_jescape = 0;


### PR DESCRIPTION
added: server admin can set a default value for client side checkbox"automatically reduce view distance at maintarget" still false for TT and true otherwise

not sure if you will like this change, normally this is a client-side setting but I would like to "force" a default on the server (but user can still change it as usual)