### PR TITLE
event trigger locations are relative to the radius of the current target

### DIFF
--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -37,7 +37,7 @@ if (_townNearbyPos isEqualTo []) exitWith {
 
 private _x_mt_event_ar = [];
 
-private _trigger = [_target_center, [475,475,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
+private _trigger = [_target_center, [d_cur_target_radius,d_cur_target_radius,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
 
 waitUntil {sleep 0.1; !isNil {_trigger getVariable "d_event_start"}};
 

--- a/co30_Domination.Altis/missions/events/fn_event_markedfordeath.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_markedfordeath.sqf
@@ -16,7 +16,7 @@ params ["_target_radius", "_target_center"];
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
-private _trigger = [_target_center, [120,120,0,false,10], ["ANYPLAYER","PRESENT",true], ["this","thisTrigger setVariable ['d_event_start_time', time];",""]] call d_fnc_CreateTriggerLocal;
+private _trigger = [_target_center, [(d_cur_target_radius * 0.50),(d_cur_target_radius * 0.50),0,false,10], ["ANYPLAYER","PRESENT",true], ["this","thisTrigger setVariable ['d_event_start_time', time];",""]] call d_fnc_CreateTriggerLocal;
 
 private _event_start_time = nil;
 private _event_target = nil;

--- a/co30_Domination.Altis/missions/events/fn_event_markedfordeath.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_markedfordeath.sqf
@@ -48,6 +48,10 @@ d_kb_logic1 kbTell [
 	d_kbtel_chan
 ];
 
+private _event_description = format [localize "STR_DOM_MISSIONSTRING_MARKEDFORDEATH", _event_target_name, _event_survive_time];
+d_mt_event_messages_array pushBack _event_description;
+publicVariable "d_mt_event_messages_array";
+
 // waitUntil either killed EH or _event_survive_time duration
 waitUntil {sleep 3;d_priority_targets isEqualTo []  || {(time - _event_start_time) > _event_survive_time}};
 
@@ -84,4 +88,5 @@ if (d_priority_targets isEqualTo []) then {
 };
 
 // cleanup
-// nothing?
+d_mt_event_messages_array deleteAt (d_mt_event_messages_array find _event_description);
+publicVariable "d_mt_event_messages_array";

--- a/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
@@ -19,7 +19,6 @@ private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
 private _event_succeed_points = 5;
 
-//position the event site near target center at max distance 125m and min 15m
 //position the event site at max distance 65% of target radius and min 25% of target radius
 private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_center, (d_cur_target_radius * 0.25)]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];

--- a/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
@@ -19,8 +19,9 @@ private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
 
 private _event_succeed_points = 5;
 
-//position the event site near target center at max distance 125m and min 15m 
-private _poss = [[[_target_center, 125]],[[_target_center, 15]]] call BIS_fnc_randomPos;
+//position the event site near target center at max distance 125m and min 15m
+//position the event site at max distance 65% of target radius and min 25% of target radius
+private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_center, (d_cur_target_radius * 0.25)]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];
 
 private _trigger = [_poss, [120,120,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;

--- a/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
@@ -17,8 +17,8 @@ params ["_target_radius", "_target_center"];
 
 //private _mt_event_key = format ["d_X_MTEVENT_PRISONERDEFUSE_%1", d_cur_tgt_name];
 
-//position the event site near target center at max distance 150m and min 35m, find a building position later
-private _poss = [[[_target_center, 150]],[[_target_center, 35]]] call BIS_fnc_randomPos;
+//position the event site at max distance 65% of target radius and min 25% of target radius
+private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_center, (d_cur_target_radius * 0.25)]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];
 
 //find a suitable building

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
@@ -19,8 +19,8 @@ params ["_target_radius", "_target_center"];
 
 //private _mt_event_key = format ["d_X_MTEVENT_PRISONERDEFUSE_%1", d_cur_tgt_name];
 
-//position the event site near target center at max distance 150m and min 35m, find a building position later
-private _poss = [[[_target_center, 150]],[[_target_center, 35]]] call BIS_fnc_randomPos;
+//position the event site at max distance 65% of target radius and min 25% of target radius
+private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_center, (d_cur_target_radius * 0.25)]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];
 
 //find a suitable building

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -14,9 +14,9 @@ if (!isServer) exitWith {};
 params ["_target_radius", "_target_center"];
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
-
-//position the event site near target center at max distance 125m and min 15m 
-private _poss = [[[_target_center, 125]],[[_target_center, 15]]] call BIS_fnc_randomPos;
+ 
+//position the event site at max distance 50% of target radius and min 5% of target radius
+private _poss = [[[_target_center, (d_cur_target_radius * 0.50)]],[[_target_center, (d_cur_target_radius * 0.05)]]] call BIS_fnc_randomPos;
 private _x_mt_event_ar = [];
 
 private _trigger = [_poss, [160,160,0,false,30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;

--- a/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
@@ -19,9 +19,9 @@ if (!isServer) exitWith {};
 params ["_target_radius", "_target_center"];
 
 private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
-
-//position the event site near target center at max distance 125m and min 50m 
-private _poss = [[[_target_center, 125]],[[_target_center, 50]]] call BIS_fnc_randomPos;
+ 
+//position the event site at max distance 85% of target radius and min 40% of target radius
+private _poss = [[[_target_center, (d_cur_target_radius * 0.85)]],[[_target_center, (d_cur_target_radius * 0.40)]]] call BIS_fnc_randomPos;
 private _trigger = [_poss, [65,65,0,false,10], ["ANYPLAYER","PRESENT",true], ["this","thisTrigger setVariable ['d_event_start_time', time];",""]] call d_fnc_CreateTriggerLocal;
 
 private _event_start_time = nil;


### PR DESCRIPTION
added: random maintarget event trigger locations are relative to d_cur_target_radius

supports larger target radius so events are properly spread out