### PR TITLE
new event - stop civilian massacre

### DIFF
--- a/co30_Domination.Altis/bikb/domkba3.bikb
+++ b/co30_Domination.Altis/bikb/domkba3.bikb
@@ -490,6 +490,21 @@ class Sentences {
 			class 1 {type = "simple";};
 		};
 	};
+	class MTEventCivMassacre {
+		text = "$STR_DOM_MISSIONSTRING_EVENTCIVMASSACRE";
+		speech[] = {};
+		class Arguments {
+			class 1 {type = "simple";};
+		};
+	};
+	class MTEventCivMassacreEnded {
+		text = "$STR_DOM_MISSIONSTRING_EVENTCIVMASSACRE_END";
+		speech[] = {};
+		class Arguments {
+			class 1 {type = "simple";};
+			class 2 {type = "simple";};
+		};
+	};
 };
 class Arguments{};
 class Special{};

--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -458,6 +458,7 @@ class cfgFunctions {
 			addc(event_sidevipdefend);
 			addc(event_sideprisonerdefuse);
 			addc(event_sidekilltriggerman);
+			addc(event_civ_massacre);
 		};
 		class Dom_Server {
 			file = "server";

--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -360,6 +360,12 @@ if (isNil "d_mt_event_messages_array") then {
 if (isNil "d_priority_targets") then {
 	d_priority_targets = [];
 };
+if (isNil "d_civ_massacre") then {
+	d_civ_massacre = false;
+};
+if (isNil "d_cur_tgt_civ_vehicles") then {
+	d_cur_tgt_civ_vehicles = [];
+};
 
 if (hasInterface) then {
 	if (isNil "d_MainTargets") then {d_MainTargets = count d_target_names};

--- a/co30_Domination.Altis/missions/events/fn_event_civ_massacre.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_civ_massacre.sqf
@@ -1,0 +1,65 @@
+// by Longtime
+//#define __DEBUG__
+#include "..\..\x_setup.sqf"
+
+// When triggered all enemy units will add civilians as targets in the awareness script
+// See fn_hallyg_dlegion_Snipe_awareness.sqf for more info about targeting civilians.
+// The event does not end until the maintarget is cleared.
+// TODO - Players receive one point per civilian still alive when maintarget is completed
+
+if (!isServer) exitWith {};
+
+params ["_target_radius", "_target_center"];
+
+//private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
+ 
+private _trigger = [_target_center, [(d_cur_target_radius + 50), (d_cur_target_radius + 50), 0 , false, 30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
+
+waitUntil {sleep 1; !isNil {_trigger getVariable "d_event_start"}};
+
+diag_log ["civ_massacre begins"];
+
+private _civ_count_endangered = 0;
+private _civ_count_survived = 0;
+
+{
+	if (alive _x && {_x isKindOf "CAManBase" && {side _x == civilian}}) then {
+		_civ_count_endangered = _civ_count_endangered + 1;
+	};
+} forEach (nearestObjects [_target_center, ["Man"], d_cur_target_radius]);
+
+d_kb_logic1 kbTell [
+	d_kb_logic2,
+	d_kb_topic_side,
+	"MTEventCivMassacre",
+	["1", "", str _civ_count_endangered, []],
+	d_kbtel_chan
+];
+
+d_civ_massacre = true;
+publicVariable "d_civ_massacre";
+
+
+waitUntil {sleep 5; d_mt_done};
+
+diag_log ["civ_massacre ended"];
+
+{
+	if (alive _x && {_x isKindOf "CAManBase" && {side _x == civilian}}) then {
+		_civ_count_survived = _civ_count_survived + 1;
+	};
+} forEach (nearestObjects [_target_center, ["Man"], d_cur_target_radius]);
+
+d_kb_logic1 kbTell [
+	d_kb_logic2,
+	d_kb_topic_side,
+	"MTEventCivMassacreEnded",
+	["1", "", str _civ_count_survived, []],
+	["2", "", str _civ_count_endangered, []],
+	d_kbtel_chan
+];
+
+// cleanup
+deleteVehicle _trigger;
+d_civ_massacre = false;
+publicVariable "d_civ_massacre";

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness.sqf
@@ -67,6 +67,15 @@ while {true} do {
 		} forEach (_unit nearEntities _awarenessRadius);
 		__TRACE_1("","_Dtargets")
 		
+		if (d_civ_massacre) then {
+			// these enemies are attacking civs, add nearby civs to _Dtargets array
+			{
+				if (alive _x && {_x isKindOf "CAManBase" && {side _x == civilian}}) then {
+					_Dtargets pushBack [_x distance2D _unit, _x];
+				};
+			} forEach (nearestObjects [_unit, ["Man"], 50]);
+		};
+		
 		private _fired = false;
 		private _targets = [];
 		
@@ -92,6 +101,10 @@ while {true} do {
 							//to check if unit actually fired
 							_ammoCount = _unit ammo primaryWeapon _unit;
 							_magazineCount = count magazinesAmmo _unit; 
+							if (alive _x && {_x isKindOf "CAManBase" && {side _x == civilian}}) then {
+								// targeting a civ, make the civ a renegade so enemy will engage
+								_x addRating -10000;
+							};
 							// execute aggressive shooting
 							_unit doTarget _x;
 							_unit doSuppressiveFire _x;

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -470,10 +470,6 @@ if (d_allow_observers == 1 && {d_no_more_observers < 2}) then {
 if (d_enable_civ_vehs > 0) then {
 	_roadList = _trg_center nearroads d_enable_civ_vehs_rad;
 	
-	if (isNil "d_cur_tgt_civ_vehicles") then {
-		d_cur_tgt_civ_vehicles = [];
-	};
-	
 	{
 		_roadConnectedTo = roadsConnectedTo _x;
 		
@@ -783,6 +779,9 @@ if (d_with_MainTargetEvents != 0) then {
 			};
 			case "KILL_TRIGGERMAN": {
 				[_radius, _trg_center] spawn d_fnc_event_sidekilltriggerman;
+			};
+			case "CIV_MASSACRE": {
+				[_radius, _trg_center] spawn d_fnc_event_civ_massacre;
 			};
 		};
 	};

--- a/co30_Domination.Altis/server/fn_serverinit.sqf
+++ b/co30_Domination.Altis/server/fn_serverinit.sqf
@@ -23,12 +23,24 @@ d_x_mt_event_types = [
 	"POW_RESCUE",
 	//"GUERRILLA_TANKS", //not in the random events list, guerrilla tanks event depends on presence of guerrilla infantry
 	"GUERRILLA_INFANTRY",
-	"RABBIT_RESCUE",
+	//"RABBIT_RESCUE", // removed for now
 	"MARKED_FOR_DEATH",
 	"RESCUE_DEFEND",
 	"RESCUE_DEFUSE",
-	"KILL_TRIGGERMAN"
+	"KILL_TRIGGERMAN",
+	"CIV_MASSACRE" //requires awareness/aggressiveshoot
 ];
+
+if (d_ai_awareness_rad < 0 && {d_ai_aggressiveshoot == 0}) then {
+	// server is not configured to use awareness/aggressiveshoot script, remove events that won't work 
+	d_x_mt_event_types deleteAt (_tmpMtEvents find "CIV_MASSACRE");
+};
+
+if (d_enable_civs == 0) then {
+	// server is not configured to use civilians, remove events that won't work 
+	d_x_mt_event_types deleteAt (_tmpMtEvents find "CIV_MASSACRE");
+};
+
 d_x_mt_event_ar = [];
 d_x_mt_event_pos = [];
 

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -12193,6 +12193,30 @@
 <Chinese>Move quickly! Only %1 seconds.</Chinese>
 <French>Move quickly! Only %1 seconds.</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_EVENTCIVMASSACRE">
+<English>The enemy is killing civilians. %1 people are in danger!</English>
+<Spanish>The enemy is killing civilians. %1 people are in danger!</Spanish>
+<Portuguese>The enemy is killing civilians. %1 people are in danger!</Portuguese>
+<Korean>The enemy is killing civilians. %1 people are in danger!</Korean>
+<Japanese>The enemy is killing civilians. %1 people are in danger!</Japanese>
+<Original>The enemy is killing civilians. %1 people are in danger!</Original>
+<Russian>The enemy is killing civilians. %1 people are in danger!</Russian>
+<Chinesesimp>The enemy is killing civilians. %1 people are in danger!</Chinesesimp>
+<Chinese>The enemy is killing civilians. %1 people are in danger!</Chinese>
+<French>The enemy is killing civilians. %1 people are in danger!</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_EVENTCIVMASSACRE_END">
+<English>%1 out of %2 civilians survived the massacre.</English>
+<Spanish>%1 out of %2 civilians survived the massacre.</Spanish>
+<Portuguese>%1 out of %2 civilians survived the massacre.</Portuguese>
+<Korean>%1 out of %2 civilians survived the massacre.</Korean>
+<Japanese>%1 out of %2 civilians survived the massacre.</Japanese>
+<Original>%1 out of %2 civilians survived the massacre.</Original>
+<Russian>%1 out of %2 civilians survived the massacre.</Russian>
+<Chinesesimp>%1 out of %2 civilians survived the massacre.</Chinesesimp>
+<Chinese>%1 out of %2 civilians survived the massacre.</Chinese>
+<French>%1 out of %2 civilians survived the massacre.</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1890CIVVEH">
 <English>Civilian vehicles - enabled</English>
 <Spanish>Vehículos civiles - habilitados</Spanish>


### PR DESCRIPTION
added: new event - stop civilian massacre, available when awareness or aggressiveshoot is enabled and civilians are present