### PR TITLE
Only run civ event when guerrillas enabled

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -474,6 +474,7 @@ class Params {
 		title = "$STR_DOM_MISSIONSTRING_1052_EVENTS";
 		values[] = {0,1,2,-1,-2,-3,-4};
 		default = 0;
+		// never, low, medium, always, always multiple events, always multiple events with guerrillas, all
 		texts[] = {"$STR_DOM_MISSIONSTRING_418","$STR_DOM_MISSIONSTRING_399","$STR_DOM_MISSIONSTRING_399B","$STR_DOM_MISSIONSTRING_418B","$STR_DOM_MISSIONSTRING_418C","$STR_DOM_MISSIONSTRING_418C_GUERR","$STR_DOM_MISSIONSTRING_ALL"};
 	};
 	

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -803,9 +803,10 @@ if (d_with_MainTargetEvents != 0) then {
 			// create multiple simultaneous events		
 			private _tmpMtEvents = + d_x_mt_event_types;
 			if (d_with_MainTargetEvents != -3 && {d_with_MainTargetEvents != -4}) then {
-            	// guerrilla events are only eligible if d_with_MainTargetEvents == -3 or -4
-            	// remove guerrilla events from the temp array, do not select it here
+            	// some events are only eligible if d_with_MainTargetEvents == -3 or -4
+            	// remove ineligible events from the temp array
             	_tmpMtEvents deleteAt (_tmpMtEvents find "GUERRILLA_INFANTRY");
+            	_tmpMtEvents deleteAt (_tmpMtEvents find "CIV_MASSACRE");
 			};
 			private _num_events_for = 2; // default three events for iterator starting at zero
 			if (d_with_MainTargetEvents == -4) then {


### PR DESCRIPTION
high CPU events are now under "with guerrillas" selection, helps low CPU servers avoid events that cause lag