### PR TITLE
Civs removed near mt objectives

### DIFF
--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -367,6 +367,10 @@ if (isNil "d_cur_tgt_civ_vehicles") then {
 	d_cur_tgt_civ_vehicles = [];
 };
 
+if (isNil "d_mt_tower") then {
+	d_mt_tower_pos = [];
+};
+
 if (hasInterface) then {
 	if (isNil "d_MainTargets") then {d_MainTargets = count d_target_names};
 };

--- a/co30_Domination.Altis/missions/events/fn_event_civ_massacre.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_civ_massacre.sqf
@@ -13,7 +13,7 @@ params ["_target_radius", "_target_center"];
 
 //private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
  
-private _trigger = [_target_center, [(d_cur_target_radius + 50), (d_cur_target_radius + 50), 0 , false, 30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
+private _trigger = [_target_center, [round (d_cur_target_radius * 0.75), round (d_cur_target_radius * 0.75), 0 , false, 30], [d_own_side,"PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
 
 waitUntil {sleep 1; !isNil {_trigger getVariable "d_event_start"}};
 

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -813,9 +813,6 @@ if (d_with_MainTargetEvents != 0) then {
 			case "KILL_TRIGGERMAN": {
 				[_radius, _trg_center] spawn d_fnc_event_sidekilltriggerman;
 			};
-			case "CIV_MASSACRE": {
-				[_radius, _trg_center] spawn d_fnc_event_civ_massacre;
-			};
 		};
 	};
 	
@@ -839,7 +836,6 @@ if (d_with_MainTargetEvents != 0) then {
             	// some events are only eligible if d_with_MainTargetEvents == -3 or -4
             	// remove ineligible events from the temp array
             	_tmpMtEvents deleteAt (_tmpMtEvents find "GUERRILLA_INFANTRY");
-            	_tmpMtEvents deleteAt (_tmpMtEvents find "CIV_MASSACRE");
 			};
 			private _num_events_for = 2; // default three events for iterator starting at zero
 			if (d_with_MainTargetEvents == -4) then {
@@ -858,6 +854,14 @@ if (d_with_MainTargetEvents != 0) then {
 		} else {
 			// create one event
 			[selectRandom d_x_mt_event_types] call _doMainTargetEvent;
+		};
+		if (d_ai_awareness_rad < 0 && {d_enable_civs == 0 && {d_ai_aggressiveshoot == 0}}) then {
+			// awareness, civs, agressiveshoot are enabled
+			// very small chance of a civilian massacre
+			if (3 > random 100) then {
+				// bad luck for the civilians
+				[_radius, _trg_center] spawn d_fnc_event_civ_massacre;
+			};
 		};
 	};
 };

--- a/co30_Domination.Altis/server/fn_createsecondary.sqf
+++ b/co30_Domination.Altis/server/fn_createsecondary.sqf
@@ -84,6 +84,7 @@ if (_dobigtower) then {
 	_vec = createVehicle [d_illum_tower, _poss, [], 0, "NONE"];
 	_vec setVectorUp [0, 0, 1];
 };
+d_mt_tower_pos = getPos _vec;
 [_vec] call d_fnc_CheckMTHardTarget;
 d_mt_radio_down = false;
 if (d_ao_markers == 1) then {
@@ -323,6 +324,22 @@ if (d_IllumMainTarget == 0) then {
 };
 if (worldname == "Altis") then {
 	[_trg_center, _mtradius] spawn d_fnc_ambientanimals;
+};
+
+if (!isNil "d_cur_tgt_civ_units" && {count d_cur_tgt_civ_units != 0}) then {
+	// civilians exist, remove civilians spawned too close to any maintarget objectives
+	{
+		private _civ = _x;
+		if ((getPos _civ) distance2D d_mt_tower_pos < 15) exitWith {
+			deleteVehicle _civ;
+		};
+		{
+			if ((getPos _civ) distance2D (getPos _x) < 15) exitWith {
+				deleteVehicle _civ;
+			};
+		} forEach d_mt_barracks_obj_ar;
+		
+	} forEach d_cur_tgt_civ_units;
 };
 
 sleep 5.213;

--- a/co30_Domination.Altis/server/fn_serverinit.sqf
+++ b/co30_Domination.Altis/server/fn_serverinit.sqf
@@ -27,19 +27,8 @@ d_x_mt_event_types = [
 	"MARKED_FOR_DEATH",
 	"RESCUE_DEFEND",
 	"RESCUE_DEFUSE",
-	"KILL_TRIGGERMAN",
-	"CIV_MASSACRE" //requires awareness/aggressiveshoot
+	"KILL_TRIGGERMAN"
 ];
-
-if (d_ai_awareness_rad < 0 && {d_ai_aggressiveshoot == 0}) then {
-	// server is not configured to use awareness/aggressiveshoot script, remove events that won't work 
-	d_x_mt_event_types deleteAt (_tmpMtEvents find "CIV_MASSACRE");
-};
-
-if (d_enable_civs == 0) then {
-	// server is not configured to use civilians, remove events that won't work 
-	d_x_mt_event_types deleteAt (_tmpMtEvents find "CIV_MASSACRE");
-};
 
 d_x_mt_event_ar = [];
 d_x_mt_event_pos = [];


### PR DESCRIPTION
an ugly solution, civilians are spawned before objectives so just delete the civs that are too close to radiotower/vehicle HQ