### PR TITLE
calculate enemies and civ counts

### DIFF
--- a/Wiki_cfgparams.txt
+++ b/Wiki_cfgparams.txt
@@ -278,7 +278,7 @@
 > Default: 0 (No, disabled; 1 or Yes to enable civilians)<br/>
 #### **d_civ_unitcount / Civilian unit count (walking)**
 > Default: 10<br/>
-> Available options: 10, 15, 20, 25 and 30<br/>
+> Available options: 10, 15, 20, 25, 30, 40, 50, 75 and 100<br/>
 #### **d_civ_groupcount / Civilian group count per target**
 > Default: 2<br/>
 > Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 and 10<br/>

--- a/Wiki_cfgparams.txt
+++ b/Wiki_cfgparams.txt
@@ -276,7 +276,7 @@
 > Default: 0 (No, player cas enabled; 1 or Yes to disable it)<br/>
 #### **d_enable_civs / Enable civilians**
 > Default: 0 (No, disabled; 1 or Yes to enable civilians)<br/>
-#### **d_civ_unitcount / Civilian unit count per group**
+#### **d_civ_unitcount / Civilian unit count (walking)**
 > Default: 10<br/>
 > Available options: 10, 15, 20, 25 and 30<br/>
 #### **d_civ_groupcount / Civilian group count per target**

--- a/co30_Domination.Altis/common/fn_getbldgswithpositions.sqf
+++ b/co30_Domination.Altis/common/fn_getbldgswithpositions.sqf
@@ -7,6 +7,10 @@
 // parameters: radius
 params ["_pos", "_radius"];
 
+if (_radius isEqualType objNull) then {
+	_radius = -1;
+};
+
 private _buildingsArrayRaw = nearestObjects [_pos, ["Building", "House"], _radius, true];
 	
 if (_buildingsArrayRaw isEqualTo []) exitWith {

--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -371,6 +371,10 @@ if (isNil "d_mt_tower") then {
 	d_mt_tower_pos = [];
 };
 
+if (isNil "d_object_spawn_civ_blacklist") then {
+	d_object_spawn_civ_blacklist = ["vn_dyke.p3d", "vn_dyke_10.p3d"];
+};
+
 if (hasInterface) then {
 	if (isNil "d_MainTargets") then {d_MainTargets = count d_target_names};
 };

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -1207,9 +1207,9 @@ class Params {
 
 	class d_civ_unitcount {
 		title = "$STR_DOM_MISSIONSTRING_1893";
-		values[] = {10,15,20,25,30};
+		values[] = {10,15,20,25,30,40,50,75,100};
 		default = 10;
-		texts[] = {"10","15","20","25","30"};
+		texts[] = {"10","15","20","25","30","40","50","75","100"};
 	};
 
 	class d_civ_groupcount {
@@ -1382,9 +1382,9 @@ class Params {
 	
 	class d_grp_size_override {
 		title = "$STR_DOM_MISSIONSTRING_1900GROUPSIZE";
-		values[] = {-1, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-		default = -1;
-		texts[] = {"$STR_DOM_MISSIONSTRING_418DEFAULT", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+		values[] = {0, 1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_418DEFAULT", "$STR_DOM_MISSIONSTRING_400"};
 	};
 	
 	class d_camp_static_weapons {

--- a/co30_Domination.Altis/missions/events/fn_event_guerrillas_embedded_as_civilians.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrillas_embedded_as_civilians.sqf
@@ -18,7 +18,7 @@ params [
 	["_join_player", false]
 ];
 
-private _buildings = [_target_center, (_target_radius * 0.75)] call d_fnc_getbuildings;
+private _buildings = [_target_center, (_target_radius * 0.75)] call d_fnc_getbldgswithpositions;
 if (count _buildings < 1) exitWith {};
 
 private _eventDescription = localize "STR_DOM_MISSIONSTRING_CIV_RESISTANCE";

--- a/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
@@ -22,7 +22,7 @@ private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_cent
 private _x_mt_event_ar = [];
 
 //find a suitable building
-_buildings_array_sorted_by_distance = [[_poss, 200, nil, 1] call d_fnc_getbuildings, _poss] call d_fnc_sortarraybydistance;
+_buildings_array_sorted_by_distance = [[_poss, 200] call d_fnc_getbldgswithpositions, _poss] call d_fnc_sortarraybydistance;
 private _unitsNotGarrisoned = [];
 private _bldg = nil;
 private _marker = nil;

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
@@ -24,7 +24,7 @@ private _poss = [[[_target_center, (d_cur_target_radius * 0.65)]],[[_target_cent
 private _x_mt_event_ar = [];
 
 //find a suitable building
-_buildings_array_sorted_by_distance = [[_poss, 200, nil, 1] call d_fnc_getbuildings, _poss] call d_fnc_sortarraybydistance;
+_buildings_array_sorted_by_distance = [[_poss, 200] call d_fnc_getbldgswithpositions, _poss] call d_fnc_sortarraybydistance;
 private _unitsNotGarrisoned = [];
 private _bldg = nil;
 private _marker = nil;

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -84,7 +84,7 @@ private _enemyGuardGroup = (["specops", 0, "allmen", 1, _nposss , 5, false, true
 } forEach (units _enemyGuardGroup);
 
 //find a suitable building and occupy
-_buildings_array_sorted_by_distance = [[_poss, 200, nil, (count _allActors)] call d_fnc_getbuildings, _poss] call d_fnc_sortarraybydistance;
+_buildings_array_sorted_by_distance = [[_poss, 200] call d_fnc_getbldgswithpositions, _poss] call d_fnc_sortarraybydistance;
 private _unitsNotGarrisoned = [];
 private _bldg = nil;
 private _marker = nil;

--- a/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
@@ -69,7 +69,7 @@ if (d_with_dynsim == 0) then {
 sleep 2.333;
 
 //find a suitable building and occupy
-_buildings_array_sorted_by_distance = [[_poss, 200, nil, (count _allActors)] call d_fnc_getbuildings, _poss] call d_fnc_sortarraybydistance;
+_buildings_array_sorted_by_distance = [[_poss, 200] call d_fnc_getbldgswithpositions, _poss] call d_fnc_sortarraybydistance;
 private _unitsNotGarrisoned = [];
 private _bldg = nil;
 private _marker = nil;

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -149,7 +149,7 @@ _spawn_script_enable_movement = {
 	};
 };
 
-_buildingsArrayFiltered = [_center, _buildingRadius, d_side_enemy] call d_fnc_getbuildings;
+_buildingsArrayFiltered = [_center, _buildingRadius] call d_fnc_getbldgswithpositions;
 
 _buildingPosArray = [];
 0 = [_buildingsArrayFiltered] call _Zen_ArrayShuffle;

--- a/co30_Domination.Altis/scripts/fn_afterfirednear.sqf
+++ b/co30_Domination.Altis/scripts/fn_afterfirednear.sqf
@@ -24,18 +24,17 @@ while {alive _unit} do {
 			_last_threatened_ts = time;
 			_unit setVariable ["civ_last_firednear_or_threatened", _last_threatened_ts];
 		};
-	} forEach (allPlayers select { _x distance2D _unit < 4 });
+	} forEach (allPlayers select { _x distance2D _unit < 6 });
 	private _elapsed_time_since_threatened = (time - _last_threatened_ts);
 	if (_elapsed_time_since_threatened > 10 && {_civ_is_walking}) then {
 		_unit forceSpeed -1;
 	};
 	if (_elapsed_time_since_threatened > 30 && {_elapsed_time_since_threatened <= 45}) then {
-		sleep random 3;
 		_unit setUnitPos "MIDDLE";
 	};
 	if (_elapsed_time_since_threatened > 45) then {
 		_unit setBehaviour "SAFE";
 		_unit setUnitPos "AUTO";
 	};
-	sleep 3;
+	sleep (1 max random 3);
 };

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -285,7 +285,6 @@ for "_i" from 0 to _civ_grp_count do {
 
 	__TRACE("Placing a civilian cluster...")
 	[_grp] call _placeCivilianCluster;
-	diag_log [format ["_total_civs_count_created: %1", _total_civs_count_created]];
 };
 
 diag_log [format ["total static civs created: %1", _total_civs_count_created]];

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -171,26 +171,40 @@ d_civArray = [
 	];
 #endif
 
-private _buildings = [_trg_center, _radius] call d_fnc_getbuildings;
+private _civ_units_count_max = 100;
+
+private _buildings_unfiltered = [_trg_center, _radius] call d_fnc_getbldgswithpositions;
+
+private _buildings = _buildings_unfiltered select { !(getModelInfo _x # 0 in d_object_spawn_civ_blacklist) };
+
+diag_log [format ["total possible buildings to spawn civs: %1", count (_buildings)]];
+
+private _total_civs_count_created = 0;
 
 //create a cluster of civilians (does not use civilian module)
 private _placeCivilianCluster = {
-	if (count _buildings < 1) exitWith {};
-	_civPos = _this # 0;
-	_grp = _this # 1;
-	_unitCount = _this # 2;
+	if (count _buildings < 1 || {_total_civs_count_created > _civ_units_count_max}) exitWith {};
+	_grp = _this # 0;
 	_bldg = selectRandom _buildings;
 	_buildings deleteAt (_buildings find _bldg);
 	if (typeOf _bldg == d_barracks_building || {typeOf _bldg == d_vehicle_building}) exitWith {
 		// oops, we randomly chose a vehicle or infantry HQ, do not place the civilian cluster just skip
 	};
 	_posArray = _bldg buildingPos -1;
-	_posArrayCovered = [_posArray] call d_fnc_getcoveredpositions;
-	for "_i" from 0 to _unitCount do {
-		if (_posArrayCovered isEqualTo []) exitWith {};
-		_randomPos = selectRandom _posArrayCovered;
-		_posArrayCovered deleteAt (_posArrayCovered find _randomPos);
-		_civAgent = createAgent [selectRandom d_civArray, _randomPos, [], 1.5, "NONE"];
+	_unit_count = 2 max floor(random (count _posArray));
+	if (count _posArray > 5 && {1 > random 13}) then {
+		// small chance for larger buildings (more than 5 positions) to have many civs
+		_unit_count = count _posArray - 1;
+	};
+	for "_i" from 0 to _unit_count do {
+		if (_posArray isEqualTo []) exitWith {
+			diag_log ["foooooooooo no covered positions, exitWith!"];
+		};
+		diag_log [_i];
+		_randomPos = selectRandom _posArray;
+		_posArray deleteAt (_posArray find _randomPos);
+		_civAgent = createAgent [selectRandom d_civArray, _randomPos, [], 0, "NONE"];
+		_total_civs_count_created = _total_civs_count_created + 1;
 		if (random 2 <= 1) then {
 			if (random 2 <= 1) then {
 				[_civAgent, "SIT_LOW"] call BIS_fnc_ambientAnim;
@@ -204,7 +218,7 @@ private _placeCivilianCluster = {
 				if (((animationState _unit) find "sit") > 0) then {
 					_unit call BIS_fnc_ambientAnim__terminate;
 				};
-				if (_distance < 7) then {
+				if (_distance < 10) then {
 					_unit setUnitPos "DOWN";
 				} else {
 					_unit setUnitPos "MIDDLE";
@@ -239,29 +253,27 @@ __TRACE_1("","_marker_name")
 
 private _civ_grp_count = d_civ_groupcount;
 private _civ_spawn_factor = 0; // determines number of static civs in houses
-private _civ_unitcount = 10; // determines number of walking civs, module minimum is 10
 if (d_civ_groupcount < 0) then {
 	if (d_civ_groupcount == -1) then {
-		_civ_spawn_factor = 0.20;  // adaptive (low)
+		_civ_spawn_factor = 0.15;  // adaptive (low)
 	};
 	if (d_civ_groupcount == -2) then {
-		_civ_spawn_factor = 0.35;  // adaptive (normal)
-		_civ_unitcount = 15;
+		_civ_spawn_factor = 0.25;  // adaptive (normal)
 	};
 	if (d_civ_groupcount == -3) then {
-		_civ_spawn_factor = 0.55;  // adaptive (high)
-		_civ_unitcount = 20;
+		_civ_spawn_factor = 0.40;  // adaptive (high)
 	};
 	if (d_civ_groupcount == -4) then {
-		_civ_spawn_factor = 0.75;  // adaptive (very high)
-		_civ_unitcount = 25;
+		_civ_spawn_factor = 0.65;  // adaptive (very high)
 	};
 	if (d_civ_groupcount == -5) then {
-		_civ_spawn_factor = 1.00;  // adaptive (extreme)
-		_civ_unitcount = 35;
+		_civ_spawn_factor = 0.90;  // adaptive (extreme)
 	};
-	private _bldg_count = count ([_trg_center, d_snp_rad] call d_fnc_getbldgswithpositions);
-	_civ_grp_count = floor (_bldg_count * _civ_spawn_factor);
+	private _bldg_count = count ([_trg_center, _radius] call d_fnc_getbldgswithpositions);
+	private _civ_grp_count_max = floor(_civ_spawn_factor * 100); // sanity check, avoid spawning too many civ groups
+	private _civ_units_count_max = floor(_civ_grp_count_max * 3.5); // sanity check, avoid spawning too many civ units 
+	_civ_grp_count = floor (_bldg_count * _civ_spawn_factor) min _civ_grp_count_max;
+	diag_log [format ["civilian bldg_count: %1, civ_grp_count: %2", _bldg_count, _civ_grp_count]];
 };
 
 // create civilians with createAgent (not the civilian module)
@@ -274,8 +286,11 @@ for "_i" from 0 to _civ_grp_count do {
 	_grp = createGroup [civilian, true];
 
 	__TRACE("Placing a civilian cluster...")
-	[_randomPos, _grp, d_civ_unitcount] call _placeCivilianCluster;
+	[_grp] call _placeCivilianCluster;
+	diag_log [format ["fooooooooo _total_civs_count_created: %1", _total_civs_count_created]];
 };
+
+diag_log [format ["total static civs created: %1", _total_civs_count_created]];
 
 // create civilian module and use the module to spawn moving civilians (walking/running)
 // only create one module and a few civilians, too many moving civilians are distracting
@@ -313,7 +328,7 @@ d_cur_tgt_civ_modules_presence pushBack _m;
 _m setVariable ["#area", [_trg_center, 1000, 1000, 0, true, -1]];  // Fixed! this gets passed to https://community.bistudio.com/wiki/inAreaArray
 _m setVariable ["#useagents", true];
 _m setVariable ["#usepanicmode", false];
-_m setVariable ["#unitcount", _civ_unitcount];
+_m setVariable ["#unitcount", d_civ_unitcount];
 _m setVariable ["#onCreated", {
 	d_cur_tgt_civ_units pushBack _this;
 	if (d_ai_persistent_corpses == 0) then {

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -197,9 +197,7 @@ private _placeCivilianCluster = {
 		_unit_count = count _posArray - 1;
 	};
 	for "_i" from 0 to _unit_count do {
-		if (_posArray isEqualTo []) exitWith {
-			diag_log ["foooooooooo no covered positions, exitWith!"];
-		};
+		if (_posArray isEqualTo []) exitWith {};
 		diag_log [_i];
 		_randomPos = selectRandom _posArray;
 		_posArray deleteAt (_posArray find _randomPos);
@@ -287,7 +285,7 @@ for "_i" from 0 to _civ_grp_count do {
 
 	__TRACE("Placing a civilian cluster...")
 	[_grp] call _placeCivilianCluster;
-	diag_log [format ["fooooooooo _total_civs_count_created: %1", _total_civs_count_created]];
+	diag_log [format ["_total_civs_count_created: %1", _total_civs_count_created]];
 };
 
 diag_log [format ["total static civs created: %1", _total_civs_count_created]];

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -514,7 +514,7 @@ if (d_enable_civ_vehs > 0) then {
 
 	_roadList=_roadList call BIS_fnc_arrayShuffle;
 	
-	private _max_car_count = floor(d_enable_civ_vehs * 2.25); // the max is variable, "medium" is 112 cars (50*2.25)
+	private _max_car_count = floor(d_enable_civ_vehs * 2.25); // sanity check, avoid spawning too many cars
 	_carSpawns = round((count _roadList) * d_enable_civ_vehs / 100) min _max_car_count;
 	diag_log [format ["creating %1 cars (calculated allowable is %2)"], _carSpawns, _max_car_count];
 	

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -506,15 +506,17 @@ if (d_enable_civ_vehs > 0) then {
 	{
 		_roadConnectedTo = roadsConnectedTo _x;
 		
-		if (count _roadConnectedTo > 2 || {count (roadsConnectedTo (_roadConnectedTo # 0)) > 2 || {count (roadsConnectedTo (_roadConnectedTo # 1)) > 2 || {((nearestBuilding _x) distance2D _x) > 40}}}) then {
-			//only has 2 connections, children also only have 2 connections, is within 40m of a building
+		if (count _roadConnectedTo > 2 || {count (roadsConnectedTo (_roadConnectedTo # 0)) > 2 || {count (roadsConnectedTo (_roadConnectedTo # 1)) > 2 || {((nearestBuilding _x) distance2D _x) > 20}}}) then {
+			//only has 2 connections, children also only have 2 connections, is within 20m of a building
 			_roadList=_roadList - [_x];	
 		};
 	} foreach _roadList;
 
 	_roadList=_roadList call BIS_fnc_arrayShuffle;
 	
-	_carSpawns = round((count _roadList) * d_enable_civ_vehs / 100);
+	private _max_car_count = floor(d_enable_civ_vehs * 2.25); // the max is variable, "medium" is 112 cars (50*2.25)
+	_carSpawns = round((count _roadList) * d_enable_civ_vehs / 100) min _max_car_count;
+	diag_log [format ["creating %1 cars (calculated allowable is %2)"], _carSpawns, _max_car_count];
 	
 	for "_i" from 1 to _carSpawns do {
 		_currentRoad = _roadList # _i;
@@ -575,15 +577,19 @@ if (d_occ_bldgs == 1) then {
 			_occ_spawn_factor = 0.75;  // adaptive (extreme)
 		};
 		private _bldg_count = count ([_trg_center, d_occ_rad] call d_fnc_getbldgswithpositions);
-		_occ_cnt = floor (_bldg_count * _occ_spawn_factor);
+		private _occ_cnt_max = floor(_occ_spawn_factor * 100);
+		_occ_cnt = floor (_bldg_count * _occ_spawn_factor) min _occ_cnt_max;
+		diag_log [format ["_occ_cnt adaptive value: %1", _occ_cnt]];
 	} else {
 		_occ_cnt = d_occ_cnt;
 	};
+	
+	diag_log [format ["creating occupy groups _occ_cnt: %1", _occ_cnt]];
 	if (_occ_cnt > 0) then {
 		for "_xx" from 0 to (_occ_cnt - 1) do {
 			private _unitstog = [
 				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
-				selectRandom [2, 3, 4],			//unit count
+				-1,
 				d_occ_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
@@ -617,15 +623,18 @@ if (d_occ_bldgs == 1) then {
 			_ovrw_spawn_factor = 0.75;  // adaptive (extreme)
 		};
 		private _bldg_count = count ([_trg_center, d_ovrw_rad] call d_fnc_getbldgswithpositions);
-		_ovrw_cnt = floor (_bldg_count * _ovrw_spawn_factor);
+		private _ovrw_cnt_max = floor(_ovrw_spawn_factor * 100);
+		_ovrw_cnt = floor (_bldg_count * _ovrw_spawn_factor) min _ovrw_cnt_max;
+		diag_log [format ["_ovrw_cnt adaptive value: %1", _ovrw_cnt]];
 	} else {
 		_ovrw_cnt = d_ovrw_cnt;
 	};
+	diag_log [format ["creating overwatch groups _ovrw_cnt: %1", _ovrw_cnt]];
 	if (_ovrw_cnt > 0) then {
 		for "_xx" from 0 to (_ovrw_cnt - 1) do {
 			private _unitstog = [
 				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
-				selectRandom [2, 3, 4],			//unit count
+				-1,
 				d_ovrw_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
@@ -659,15 +668,18 @@ if (d_occ_bldgs == 1) then {
 			_amb_spawn_factor = 0.85;  // adaptive (extreme)
 		};
 		private _bldg_count = count ([_trg_center, d_amb_rad] call d_fnc_getbldgswithpositions);
-		_amb_cnt = floor (_bldg_count * _amb_spawn_factor);
+		private _amb_cnt_max = floor(_amb_spawn_factor * 100);
+		_amb_cnt = floor (_bldg_count * _amb_spawn_factor) min _amb_cnt_max;
+		diag_log [format ["_amb_cnt adaptive value: %1", _amb_cnt]];
 	} else {
 		_amb_cnt = d_amb_cnt;
 	};
+	diag_log [format ["creating ambush groups _amb_cnt: %1", _amb_cnt]];
 	if (_amb_cnt > 0) then {
 		for "_xx" from 0 to (_amb_cnt - 1) do {
 			private _unitstog = [
 				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
-				selectRandom [3, 4],		//unit count
+				-1,
 				d_amb_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
@@ -701,10 +713,13 @@ if (d_occ_bldgs == 1) then {
 			_snp_spawn_factor = 0.75;  // adaptive (extreme)
 		};
 		private _bldg_count = count ([_trg_center, d_snp_rad] call d_fnc_getbldgswithpositions);
-		_snp_cnt = floor (_bldg_count * _snp_spawn_factor);
+		private _snp_cnt_max = floor(_snp_spawn_factor * 100);
+		_snp_cnt = floor (_bldg_count * _snp_spawn_factor) min _snp_cnt_max;
+		diag_log [format ["_snp_cnt adaptive value: %1", _snp_cnt]];
 	} else {
 		_snp_cnt = d_snp_cnt;
 	};
+	diag_log [format ["creating sniper groups _snp_cnt: %1", _snp_cnt]];
 	if (_snp_cnt > 0) then {
 		//START create garrisoned groups of snipers
 		//prepare to create garrisoned groups of snipers - find and sort buildings

--- a/co30_Domination.Altis/server/fn_garrisonUnits.sqf
+++ b/co30_Domination.Altis/server/fn_garrisonUnits.sqf
@@ -2,7 +2,17 @@
 //#define __DEBUG__
 #include "..\x_setup.sqf"
 
-params ["_centerPos", "_numUnits", "_fillRadius", "_fillRoof", "_fillEvenly", "_fillTopDown", "_disableTeleport", "_unitMovementMode"];
+params ["_centerPos",
+	"_maxNumUnits",			// limits but does not increase the size of the team, -1 for no max
+	"_fillRadius",
+	"_fillRoof",
+	"_fillEvenly",
+	"_fillTopDown",
+	"_disableTeleport",
+	"_unitMovementMode"		// passed to zen_occupyhouse and also used in this script to determine which units to create
+							// 0 - "allmen" units with regular movement
+							// 1 - "sniper" units and cannot move
+];
 
 __TRACE("from createmaintarget garrison function")
 
@@ -12,8 +22,8 @@ private _unitlist = [["allmen", "sniper"] select (_unitMovementMode == 2), d_ene
 
 __TRACE_1("","_unitlist")
 
-if (count _unitlist > _numUnits) then {
-	while {count _unitlist > _numUnits} do {
+if (_maxNumUnits > 0 && {count _unitlist > _maxNumUnits}) then {
+	while {count _unitlist > _maxNumUnits} do {
 		_unitlist deleteAt (ceil (random (count _unitlist - 1)));
 	};
 };
@@ -66,6 +76,7 @@ _unitsNotGarrisoned = [
 sleep 0.01;
 __TRACE_1("","_unitsNotGarrisoned")
 _units_to_garrison = _units_to_garrison - _unitsNotGarrisoned;
+diag_log [format ["units not garrisoned and will be deleted: %1", _unitsNotGarrisoned joinString "/"]];
 {deleteVehicle _x} forEach _unitsNotGarrisoned;
 if (_units_to_garrison isEqualTo []) exitWith {
 	deleteGroup _newgroup;

--- a/co30_Domination.Altis/server/fn_getunitlistm.sqf
+++ b/co30_Domination.Altis/server/fn_getunitlistm.sqf
@@ -18,7 +18,7 @@ if (!d_with_ace) then {
 		_ret resize (selectRandom [6, 7]);
 	};
 } else {
-	if (count _ret > 5) then {
+	if (d_grp_size_override != 1 && {count _ret > 5}) then {
 		_ret resize (selectRandom [4, 5, 6]);
 	};
 };

--- a/co30_Domination.Altis/server/fn_makegroup.sqf
+++ b/co30_Domination.Altis/server/fn_makegroup.sqf
@@ -52,9 +52,9 @@ if (_numvecs > 0) then {
 } else {
 	__TRACE("from makegroup")
 #ifndef __TT__
-	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true, [-1, d_grp_size_override] select (d_grp_size_override > 0), d_side_player] call d_fnc_makemgroup;
+	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true, -1, d_side_player] call d_fnc_makemgroup;
 #else
-	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true ,[-1, d_grp_size_override] select (d_grp_size_override > 0), [blufor, opfor]] call d_fnc_makemgroup;
+	_uinf = [_pos, [_grptype, _side] call d_fnc_getunitlistm, _grp, _mchelper, true ,-1, [blufor, opfor]] call d_fnc_makemgroup;
 #endif
 	__TRACE_1("","_uinf")
 };

--- a/co30_Domination.Altis/server/fn_makemgroup.sqf
+++ b/co30_Domination.Altis/server/fn_makemgroup.sqf
@@ -8,7 +8,7 @@ params [
 	["_grp", ""],
 	["_mchelper", true],					// man create helper function for positioning
 	["_doreduce", false],					// allows the caller to disable d_smallgrps
-	["_unitsPerGroup", -1],					// allows the caller to specify max unit count
+	["_unitsPerGroupMax", -1],					// allows the caller to specify max unit count
 	["_sideToEngage", [sideUnknown]]		// only used when AI awareness parameters are enabled
 ];
 
@@ -27,8 +27,8 @@ __TRACE_2("","_mchelper","_doreduce")
 
 private _ret = [];
 
-if ((d_smallgrps == 0 && {_doreduce}) || {_unitsPerGroup > 0}) then {
-	_unitliste = [_unitliste, _unitsPerGroup] call d_fnc_ulreduce;
+if ((d_smallgrps == 0 && {_doreduce}) || {_unitsPerGroupMax > 0}) then {
+	_unitliste = [_unitliste, _unitsPerGroupMax] call d_fnc_ulreduce;
 };
 
 _ret resize (count _unitliste);

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -12282,16 +12282,16 @@
 <French>Civilians - Activer les civils</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1893">
-<English>Civilians - civilian unit count per group</English>
-<Spanish>Recuento de unidades civiles por grupo</Spanish>
-<Portuguese>Contagem de unidades civis por grupo</Portuguese>
-<Korean>시민 - 그룹당 시민 수</Korean>
-<Japanese>Civilians - civilian unit count per group</Japanese>
-<Original>Civilians - civilian unit count per group</Original>
-<Russian>Civilians - Количество гражданских групп</Russian>
-<Chinesesimp>平民 - 每组平民单位数</Chinesesimp>
-<Chinese>Civilians - 每組平民單位數</Chinese>
-<French>Civilians - nombre d'unités civiles par groupe</French>
+<English>Civilians - civilian unit count (walking)</English>
+<Spanish>Recuento de unidades civiles (para caminar)</Spanish>
+<Portuguese>Contagem de unidades civis (walking)</Portuguese>
+<Korean>시민 - 그룹당 시민 수 (walking)</Korean>
+<Japanese>Civilians - civilian unit count (walking)</Japanese>
+<Original>Civilians - civilian unit count (walking)</Original>
+<Russian>Civilians - Количество гражданских (walking)</Russian>
+<Chinesesimp>平民 - 每组平民单位数 (walking)</Chinesesimp>
+<Chinese>Civilians - 每組平民單位數 (walking)</Chinese>
+<French>Civilians - nombre d'unités civiles (walking)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1894">
 <English>Disable enemy air</English>


### PR DESCRIPTION
added: better logic to determine the number of spawned enemy and civ units, enforce sane limits

changes civ spawn locations, not using the "covered positions" function

added a blacklist for buildings that should not be used for civilians, useful in SOG maps (dyke objects are incorrectly considered buildings)