### PR TITLE
show headshot details in side chat

### DIFF
--- a/Wiki_cfgparams.txt
+++ b/Wiki_cfgparams.txt
@@ -274,6 +274,8 @@
 > Default: 1 (Yes, check for friendly units; 0 or No to disable it)<br/>
 #### **d_disable_player_cas / Disable player CAS**
 > Default: 0 (No, player cas enabled; 1 or Yes to disable it)<br/>
+#### **d_show_headshots / Show headshots**
+> Default: 0 (No; 1 client only; 2 client and side chat)<br/>
 #### **d_enable_civs / Enable civilians**
 > Default: 0 (No, disabled; 1 or Yes to enable civilians)<br/>
 #### **d_civ_unitcount / Civilian unit count (walking)**

--- a/co30_Domination.Altis/bikb/domkba3.bikb
+++ b/co30_Domination.Altis/bikb/domkba3.bikb
@@ -512,6 +512,14 @@ class Sentences {
 			class 1 {type = "simple";};
 		};
 	};
+	class MTHeadshot {
+		text = "$STR_DOM_MISSIONSTRING_HEADSHOT";
+		speech[] = {};
+		class Arguments {
+			class 1 {type = "simple";};
+			class 2 {type = "simple";};
+		};
+	};
 };
 class Arguments{};
 class Special{};

--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -212,6 +212,7 @@ class cfgFunctions {
 			addc(build_ranked_gear);
 			addc(makebarmhqwait);
 			addc(zeusmarkerworkaround);
+			addc(headshot_notify);
 		};
 		class Dom_UI {
 			file = "clientui";

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -1191,6 +1191,13 @@ class Params {
 		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
 	};
 	
+	class d_show_headshots {
+		title = "$STR_DOM_MISSIONSTRING_SHOW_HEADSHOTS";
+		values[] = {0,2};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_CLIENT_ALL"};
+	};
+	
 	class d_params_dl_8_civ {
 		title = "$STR_DOM_MISSIONSTRING_1574_CIV";
 		values[] = {-66};

--- a/co30_Domination.Altis/server/fn_addheadshot.sqf
+++ b/co30_Domination.Altis/server/fn_addheadshot.sqf
@@ -22,7 +22,7 @@ if (d_show_headshots == 2) then {
 		d_kb_topic_side,
 		"MTHeadshot",
 		["1", "", name _pl, []],
-		["2", "", str _distance_fired, []],
+		["2", "", str(floor _distance_fired), []],
 		d_kbtel_chan
 	];
 };

--- a/co30_Domination.Altis/server/fn_addheadshot.sqf
+++ b/co30_Domination.Altis/server/fn_addheadshot.sqf
@@ -2,10 +2,27 @@
 //#define __DEBUG__
 #include "..\x_setup.sqf"
 
-params ["_pl"];
+params ["_pl", "_distance_fired"];
 
-private _p = d_player_hash getOrDefault [getPlayerUID _pl, -1];
-if (_p isEqualType []) then {
-	_p set [16, (_p # 16) + 1];
-	__TRACE_2("","_p","_this")
+if (d_database_found) then {
+	private _p = d_player_hash getOrDefault [getPlayerUID _pl, -1];
+	if (_p isEqualType []) then {
+		_p set [16, (_p # 16) + 1];
+		__TRACE_2("","_p","_this")
+	};
+};
+
+if (d_show_headshots in [1,2]) then {
+	//remoteExecCall ["d_fnc_headshot_notify", owner _pl]; // todo - show icon and distance client side and quickly fade
+};
+
+if (d_show_headshots == 2) then {
+	d_kb_logic1 kbTell [
+		d_kb_logic2,
+		d_kb_topic_side,
+		"MTHeadshot",
+		["1", "", name _pl, []],
+		["2", "", str _distance_fired, []],
+		d_kbtel_chan
+	];
 };

--- a/co30_Domination.Altis/server/fn_entitykilled.sqf
+++ b/co30_Domination.Altis/server/fn_entitykilled.sqf
@@ -6,12 +6,10 @@ __TRACE_1("","_this")
 
 params ["_obj"];
 
-if (d_database_found) then {
-	if (_obj isKindOf "CAManBase" && {_obj getHitIndex 2 == 1 || {_obj getHitIndex 0 == 1}}) then {
-		private _insti = _this # 2;
-		if (!isNull _insti && {isNull objectParent _insti && {isPlayer _insti}}) then {
-			_insti spawn d_fnc_addheadshot;
-		};
+if (_obj isKindOf "CAManBase" && {_obj getHitIndex 2 == 1 || {_obj getHitIndex 0 == 1}}) then {
+	private _insti = _this # 2;
+	if (!isNull _insti && {isNull objectParent _insti && {isPlayer _insti}}) then {
+		[_insti, (_insti distance2D _obj)] spawn d_fnc_addheadshot;
 	};
 };
 

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -14733,6 +14733,54 @@
 <Chinese>With auto revive if no player is nearby (less than 215m):</Chinese>
 <French>With auto revive if no player is nearby (less than 215m):</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_SHOW_HEADSHOTS">
+<English>Show headshots</English>
+<Spanish>Show headshots</Spanish>
+<Portuguese>Show headshots</Portuguese>
+<Korean>Show headshots</Korean>
+<Japanese>Show headshots</Japanese>
+<Original>Show headshots</Original>
+<Russian>Show headshots</Russian>
+<Chinesesimp>Show headshots</Chinesesimp>
+<Chinese>Show headshots</Chinese>
+<French>Show headshots</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_CLIENT_ONLY">
+<English>Client only</English>
+<Spanish>Client only</Spanish>
+<Portuguese>Client only</Portuguese>
+<Korean>Client only</Korean>
+<Japanese>Client only</Japanese>
+<Original>Client only</Original>
+<Russian>Client only</Russian>
+<Chinesesimp>Client only</Chinesesimp>
+<Chinese>Client only</Chinese>
+<French>Client only</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_CLIENT_ALL">
+<English>Client and all players</English>
+<Spanish>Client and all players</Spanish>
+<Portuguese>Client and all players</Portuguese>
+<Korean>Client and all players</Korean>
+<Japanese>Client and all players</Japanese>
+<Original>Client and all players</Original>
+<Russian>Client and all players</Russian>
+<Chinesesimp>Client and all players</Chinesesimp>
+<Chinese>Client and all players</Chinese>
+<French>Client and all players</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_HEADSHOT">
+<English>Headshot by %1 %2 m</English>
+<Spanish>Headshot by %1 %2 m</Spanish>
+<Portuguese>Headshot by %1 %2 m</Portuguese>
+<Korean>Headshot by %1 %2 m</Korean>
+<Japanese>Headshot by %1 %2 m</Japanese>
+<Original>Headshot by %1 %2 m</Original>
+<Russian>Headshot by %1 %2 m</Russian>
+<Chinesesimp>Headshot by %1 %2 m</Chinesesimp>
+<Chinese>Headshot by %1 %2 m</Chinese>
+<French>Headshot by %1 %2 m</French>
+</Key>
 </Container>
 </Package>
 </Project>


### PR DESCRIPTION
added: mission parameter to show player headshots and distance in side chat

d_show_headshots default 0 is current behavior with no headshot indicator
d_show_headshots 1 will show icon client side only (quickly fading skull and number of meters?  not yet implemented)
d_show_headshots 2 shows client and server via side chat