### PR TITLE
allow static units to move if injured, enemies now spawn on the top floor more often, civilian fixes

### DIFF
--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -330,6 +330,9 @@ if (isNil "d_cur_target_radius") then {
 if (isNil "d_mttarget_radius_patrol") then {
 	d_mttarget_radius_patrol = -1;
 };
+if (isNil "d_cur_tgt_building_positions_occupied") then {
+	d_cur_tgt_building_positions_occupied = [];
+};
 #ifndef __TT__
 if (isNil "d_heli_taxi_available") then {
 	d_heli_taxi_available = true;
@@ -372,7 +375,22 @@ if (isNil "d_mt_tower") then {
 };
 
 if (isNil "d_object_spawn_civ_blacklist") then {
-	d_object_spawn_civ_blacklist = ["vn_dyke.p3d", "vn_dyke_10.p3d"];
+	d_object_spawn_civ_blacklist = [
+		"vn_dyke.p3d",
+		"vn_dyke_10.p3d",
+		"u_addon_01_v1_f.p3d",
+		"u_addon_02_v1_f.p3d",
+		"u_addon_03_v1_f.p3d",
+		"i_addon_02_v1_f.p3d",
+		"i_addon_03_v1_f.p3d",
+		"i_addon_03mid_v1_f.p3d",
+		"i_addon_04_v1_f.p3d",
+		"stone_shed_v1_ruins_f.p3d",
+		"unfinished_building_01_f.p3d",
+		"i_garage_v1_f.p3d",
+		"i_garage_v2_f.p3d",
+		"cargo_house_slum_f.p3d"
+	];
 };
 
 if (hasInterface) then {

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -268,6 +268,7 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 												params ["_unit", "_firer"];
 												scriptName "spawn_zoh_firednear1ambush";
 												
+												// enable movement if firedNear by enemy
 												if (d_side_enemy getFriend side (group _firer) < 0.6 && {(_this # 6) isKindOf ["BulletCore", configFile >> "CfgAmmo"]}) then {
 													_unit enableAI "TARGET";
 													_unit enableAI "AUTOTARGET";
@@ -275,6 +276,21 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 													_unit forceSpeed -1;
 													_unit removeEventHandler ["FiredNear", _thisEventHandler];
 												};
+												
+												// enable movement if hit
+												if (isNil {_uuidx getVariable "d_zen_hiteh"}) then {
+													_uuidx setVariable ["d_zen_hiteh", _uuidx addEventHandler ["Hit", {
+													__TRACE_1("hit 1","_this")
+														params ["_unit", "_source", "_damage", "_instigator"];
+														scriptName "spawn_zoh_hiteh";
+														_unit enableAI "TARGET";
+														_unit enableAI "AUTOTARGET";
+														_unit enableAI "MOVE";
+														_unit forceSpeed -1;
+														_unit removeEventHandler ["Hit", _thisEventHandler];
+													}]];
+												};
+												
 											}]];
 										};
 										//enable priority movement
@@ -344,6 +360,20 @@ for [{_j = 0}, {(_unitIndex < count _units) && {(count _buildingPosArray > 0)}},
 													_unit forceSpeed -1;
 													_unit removeEventHandler ["FiredNear", _thisEventHandler];
 												};
+											}]];
+										};
+										
+										// enable movement if hit
+										if (isNil {_uuidx getVariable "d_zen_hiteh"}) then {
+											_uuidx setVariable ["d_zen_hiteh", _uuidx addEventHandler ["Hit", {
+											__TRACE_1("hit 1","_this")
+												params ["_unit", "_source", "_damage", "_instigator"];
+												scriptName "spawn_zoh_hiteh";
+												_unit enableAI "TARGET";
+												_unit enableAI "AUTOTARGET";
+												_unit enableAI "MOVE";
+												_unit forceSpeed -1;
+												_unit removeEventHandler ["Hit", _thisEventHandler];
 											}]];
 										};
 									};

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -61,7 +61,7 @@ private _placeCivilianCluster = {
 	if (_mustExit == true) exitWith {
 		diag_log ["unable to place civilian cluster, randomly chose a building that is too close to a mission objective"];
 	};
-	_posArray = _bldg buildingPos -1;
+	_posArray = (_bldg buildingPos -1) - d_cur_tgt_building_positions_occupied; // remove positions already used
 	_unit_count = 2 max floor(random (count _posArray));
 	if (count _posArray > 5 && {1 > random 13}) then {
 		// small chance for larger buildings (more than 5 positions) to have many civs
@@ -71,8 +71,10 @@ private _placeCivilianCluster = {
 	for "_i" from 0 to _unit_count do {
 		if (_posArray isEqualTo []) exitWith {};
 		_randomPos = selectRandom _posArray;
+		d_cur_tgt_building_positions_occupied pushBack _posArray;
 		_posArray deleteAt (_posArray find _randomPos);
-		_civAgent = createAgent [selectRandomWeighted d_civArray, _randomPos, [], 0, "NONE"];
+		_randomPosTerrain = [_randomPos # 0, _randomPos # 1, (_randomPos # 2) + (getTerrainHeightASL _randomPos)];
+		_civAgent = createAgent [selectRandomWeighted d_civArray, _randomPosTerrain, [], 0, "NONE"];
 		_total_civs_count_created = _total_civs_count_created + 1;
 		if (random 2 <= 1) then {
 			if (random 2 <= 1) then {

--- a/co30_Domination.Altis/server/fn_garrisonUnits.sqf
+++ b/co30_Domination.Altis/server/fn_garrisonUnits.sqf
@@ -71,7 +71,7 @@ _unitsNotGarrisoned = [
 	_fillTopDown,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
 	_disableTeleport,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
 	_unitMovementMode,   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
-	true                                                //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead
+	false //true                                                //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead // todo - fix the roof check, currently disqualifies many top floor position when set to true
 ] call d_fnc_Zen_OccupyHouse;
 sleep 0.01;
 __TRACE_1("","_unitsNotGarrisoned")

--- a/co30_Domination.Altis/server/fn_target_clear.sqf
+++ b/co30_Domination.Altis/server/fn_target_clear.sqf
@@ -243,6 +243,9 @@ if (d_enable_civs == 1) then {
 };
 #endif
 
+d_cur_tgt_building_positions_occupied = [];
+publicVariable "d_cur_tgt_building_positions_occupied";
+
 sleep 0.245;
 
 {deleteVehicle _x} forEach d_mt_fires;


### PR DESCRIPTION
fixed: ambush and overwatch units are now allowed to move once injured via a hit event handler, spawning enemies in top floor building positions does not work correctly so it is now disabled in fn_garrisonUnits.sqf until fixed, added more buildings to the spawn blacklist, keep a global list of building positions used for civilian spawns to avoid spawning civ agents on top of each other