### PR TITLE
fixed: airstrike with steeper angle of attack and high altitude

### DIFF
--- a/co30_Domination.Altis/scripts/fn_moduleCAS.sqf
+++ b/co30_Domination.Altis/scripts/fn_moduleCAS.sqf
@@ -288,7 +288,7 @@ if (canMove _plane) then {
 	scriptName "spawn_cas_available";
 	params ["_side", "_logic1", "_logic", "_topicside", "_channel"];
 	if (d_arty_unlimited == 1) then {
-		sleep 90;
+		sleep 10;
 	} else {
 		sleep d_cas_available_time;
 	};

--- a/co30_Domination.Altis/scripts/fn_moduleCAS.sqf
+++ b/co30_Domination.Altis/scripts/fn_moduleCAS.sqf
@@ -152,8 +152,8 @@ private _pos = +_posATL;
 _pos set [2, (_pos # 2) + getTerrainheightasl _pos];
 private _dir = _callerpos getDir _logico;
 
-private _dis = 3000;
-private _alt = 1000;
+private _dis = 2500;
+private _alt = 1300;
 private _pitch = atan (_alt / _dis);
 private _speed = 400 / 3.6;
 private _duration = ([0,0] distance [_dis, _alt]) / _speed;
@@ -231,7 +231,7 @@ waitUntil {
 	_plane setVelocity velocity _plane;
 
 	//--- Fire!
-	if (_fireNull && {(getPosAsl _plane) distance _pos < 1000}) then {
+	if (_fireNull && {(getPosAsl _plane) distance _pos < 1300}) then {
 		_fireNull = false;
 		terminate _fire;
 		_fire = [_plane,_weapons] spawn {

--- a/co30_Domination.Altis/scripts/fn_moduleCASAI.sqf
+++ b/co30_Domination.Altis/scripts/fn_moduleCASAI.sqf
@@ -82,8 +82,8 @@ private _pos = +_posATL;
 _pos set [2, (_pos # 2) + getTerrainheightasl _pos];
 private _dir = _callerpos getDir _logico;
 
-private _dis = 3000;
-private _alt = 1000;
+private _dis = 2500;
+private _alt = 1300;
 private _pitch = atan (_alt / _dis);
 private _speed = 400 / 3.6;
 private _duration = ([0,0] distance [_dis, _alt]) / _speed;
@@ -165,7 +165,7 @@ waitUntil {
 	_plane setVelocity velocity _plane;
 
 	//--- Fire!
-	if (_fireNull && {(getPosAsl _plane) distance _pos < 1000}) then {
+	if (_fireNull && {(getPosAsl _plane) distance _pos < 1300}) then {
 		_fireNull = false;
 		terminate _fire;
 		_fire = [_plane,_weapons] spawn {


### PR DESCRIPTION
Possible solution to CAS crashing when the flight lags.

Pros:  CAS vehicle does not crash when flight path is laggy.

Cons: the higher altitude might be max viewdistance for some players so they will only hear the A10.