### PR TITLE
Civilian near objectives penalty workaround

### DIFF
--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -102,6 +102,7 @@ class cfgFunctions {
 			addc(mark_artillery);
 			addc(call_cas);
 			addc(call_cas_bomb);
+			addc(call_cas_bomb_napalm);
 			addc(dosshowhuddo2spawn);
 			addc(player_name_huddo2);
 			addc(player_name_huddo);

--- a/co30_Domination.Altis/client/fn_call_cas_bomb_napalm.sqf
+++ b/co30_Domination.Altis/client/fn_call_cas_bomb_napalm.sqf
@@ -1,0 +1,49 @@
+// by Xeno edited by Longtime
+//#define __DEBUG__
+#include "..\x_setup.sqf"
+
+if (!hasInterface) exitWith {};
+
+#ifndef __TT__
+if !(d_cas_available) exitWith {
+	[playerSide, "HQ"] sideChat (localize "STR_DOM_MISSIONSTRING_1712");
+};
+#else
+if (d_player_side == blufor && {!d_cas_available_w} || {d_player_side == opfor && {!d_cas_available_e}}) exitWith {
+	[playerSide, "HQ"] sideChat (localize "STR_DOM_MISSIONSTRING_1712");
+};
+#endif
+
+if ((d_with_ranked || {d_database_found}) && {score player < (d_ranked_a # 22)}) exitWith {
+	[playerSide, "HQ"] sideChat format [localize "STR_DOM_MISSIONSTRING_1713", score player, d_ranked_a # 22];
+};
+
+private _target = nil;
+private _islaserd = false;
+private _lt = laserTarget player;
+if (!d_ifa3lite && {!d_gmcwg && {!d_unsung && {!d_csla && {!d_vn}}}}) then {
+
+	__TRACE_1("","_lt")
+
+	if (isNil "_lt" || {isNull _lt}) then {
+		_target = getPos _lt;
+	} else {
+		_target = _lt;
+		_islaserd = true;
+	};
+
+} else {
+	_target = screenToWorld [0.5, 0.5];
+};
+__TRACE_1("","_target")
+
+#ifdef __DEBUG__
+_arrow = "Sign_Arrow_Large_F" createVehicle [10, 10, 10];
+_arrow setPos _target;
+#endif
+
+if (player distance2D _target < 30) exitWith {
+	systemChat (localize "STR_DOM_MISSIONSTRING_1529");
+};
+
+[_target, netId player, 2] remoteExec ["d_fnc_moduleCAS_bomb", 2];

--- a/co30_Domination.Altis/client/fn_playerspawn.sqf
+++ b/co30_Domination.Altis/client/fn_playerspawn.sqf
@@ -30,6 +30,9 @@ if (_rtype == 0) then { // player died
 	if (!isNil {player getVariable "d_ccas_action_bomb"}) then {
 		player removeAction (player getVariable "d_ccas_action_bomb");
 	};
+	if (!isNil {player getVariable "d_ccas_action_bomb_napalm"}) then {
+		player removeAction (player getVariable "d_ccas_action_bomb_napalm");
+	};
 	if (player getVariable ["d_has_ffunc_aid", -9999] != -9999) then {
 		player removeAction (player getVariable "d_has_ffunc_aid");
 		player setVariable ["d_has_ffunc_aid", -9999];
@@ -145,6 +148,9 @@ if (_rtype == 0) then { // player died
 			} else {
 				player setVariable ["d_ccas_action", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711"], {call d_fnc_call_cas} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
 				player setVariable ["d_ccas_action_bomb", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS"], {call d_fnc_call_cas_bomb} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
+				if (d_vn) then {
+					player setVariable ["d_ccas_action_bomb_napalm", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS_NAPALM"], {call d_fnc_call_cas_bomb_napalm} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
+				};
 			};
 #else
 			if (d_player_side == blufor) then {

--- a/co30_Domination.Altis/client/fn_setupplayer.sqf
+++ b/co30_Domination.Altis/client/fn_setupplayer.sqf
@@ -908,6 +908,9 @@ if (isNil "d_cas_plane_avail" && {d_disable_player_cas == 0}) then {
 		} else {
 			player setVariable ["d_ccas_action", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711"], {call d_fnc_call_cas} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
 			player setVariable ["d_ccas_action_bomb", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS"], {call d_fnc_call_cas_bomb} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
+			if (d_vn) then {
+				player setVariable ["d_ccas_action_bomb_napalm", player addAction [format ["<t color='#FF0000'>%1</t>", localize "STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS_NAPALM"], {call d_fnc_call_cas_bomb_napalm} , 0, 9, true, false, "", "d_cas_available && {d_player_canu && {!(player getVariable ['d_isinaction', false]) && {!d_player_in_vec && {cameraView == 'GUNNER' && {!(screenToWorld [0.5, 0.5] inArea d_base_array) && {currentWeapon player isKindOf ['Binocular', configFile >> 'CfgWeapons']}}}}}}"]];
+			};
 		};
 #else
 		if (d_player_side == blufor) then {

--- a/co30_Domination.Altis/scripts/fn_moduleCAS_bomb.sqf
+++ b/co30_Domination.Altis/scripts/fn_moduleCAS_bomb.sqf
@@ -84,22 +84,31 @@ if (!d_ifa3lite && {!d_gmcwg && {!d_unsung && {!d_csla && {!d_vn}}}}) then {
 };
 
 private _bomb = nil;
-private _altitude = nil;
+private _altitude = 500;
 if (_wtype == 0) then {
-	_altitude = 500;
 	_bomb = "Bomb_04_F";
 	sleep (5 max random 20);
 };
 if (_wtype == 1) then {
 	_bomb = "M_Scalpel_AT"; // todo
-	_altitude = 500;
+	sleep (5 max random 10);
 };
 
 #ifdef __VN__
-// set bomb type for SOG
-// _bomb = "vn_bomb_500_blu1b_fb_ammo";
-//_bomb = "vn_bomb_15000_blu82_dc_ammo";
-_bomb = "vn_bomb_500_mk82_he_ammo";
+// default bomb type for SOG
+if (_wtype == 0) then {
+	_bomb = "vn_bomb_500_mk82_he_ammo";
+	sleep (5 max random 20);
+};
+if (_wtype == 2) then {
+	// napalm
+	_bomb = "vn_bomb_500_blu1b_fb_ammo";
+	sleep (5 max random 30);
+};
+if (_wtype == 3) then { 
+	_bomb = "vn_bomb_15000_blu82_dc_ammo"; // todo
+	sleep (5 max random 20);
+};
 #endif
 
 [_target, _start_pos, _bomb, _altitude, _callero] call d_fnc_moduleCAS_guidedmissile;

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -103,7 +103,18 @@ private _placeCivilianCluster = {
 			removeFromRemainsCollector [_this];
 		};
 		_civAgent addEventHandler ["Killed", {
-			call d_fnc_civmodulekilleh;
+			private _check_punish = true;
+			{
+				if ([_x] call d_fnc_ismissionobjective) exitWith {
+					// problem: civilians walk near mission objectives and cannot easily be moved
+					// workaround: no penalty if civilian is killed within 100m of a mission objective (collateral damage / acceptable loss)
+					_check_punish = false;
+					diag_log [format ["civ killed but do not punish getPos %1", getPos (_this # 0)]];
+				};
+			} forEach ([getPos (_this # 0), 100] call d_fnc_getbldgswithpositions);
+			if (_check_punish) then {
+				call d_fnc_civmodulekilleh;
+			};
 		}];
 		[_civAgent, selectRandom d_civ_faces] remoteExec ["setIdentity", 0, _civAgent];
 	};

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -10457,16 +10457,28 @@
 <French>Demande CAS</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS">
-<English>Call CAS Bomb</English>
-<Spanish>Call CAS Bomb</Spanish>
-<Portuguese>Call CAS Bomb</Portuguese>
-<Korean>Call CAS Bomb</Korean>
-<Japanese>Call CAS Bomb</Japanese>
-<Original>Call CAS Bomb</Original>
-<Russian>Call CAS Bomb</Russian>
-<Chinesesimp>Call CAS Bomb</Chinesesimp>
-<Chinese>Call CAS Bomb</Chinese>
-<French>Call CAS Bomb</French>
+<English>Call CAS Bomb HE</English>
+<Spanish>Call CAS Bomb HE</Spanish>
+<Portuguese>Call CAS Bomb HE</Portuguese>
+<Korean>Call CAS Bomb HE</Korean>
+<Japanese>Call CAS Bomb HE</Japanese>
+<Original>Call CAS Bomb HE</Original>
+<Russian>Call CAS Bomb HE</Russian>
+<Chinesesimp>Call CAS Bomb HE</Chinesesimp>
+<Chinese>Call CAS Bomb HE</Chinese>
+<French>Call CAS Bomb HE</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_1711_CAS_BOMB_POS_NAPALM">
+<English>Call CAS Bomb Napalm</English>
+<Spanish>Call CAS Bomb Napalm</Spanish>
+<Portuguese>Call CAS Bomb Napalm</Portuguese>
+<Korean>Call CAS Bomb Napalm</Korean>
+<Japanese>Call CAS Bomb Napalm</Japanese>
+<Original>Call CAS Bomb Napalm</Original>
+<Russian>Call CAS Bomb Napalm</Russian>
+<Chinesesimp>Call CAS Bomb Napalm</Chinesesimp>
+<Chinese>Call CAS Bomb Napalm</Chinese>
+<French>Call CAS Bomb Napalm</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1712">
 <English>CAS currently not available...</English>


### PR DESCRIPTION
I am still trying to prevent civilians from being near the maintarget objectives but they are sneaky.

This is intended to avoid penalizing players who blow up radiotowers, barracks etc where civilians will not move.