### PR TITLE
occupy script improvements and fixes

### DIFF
--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -346,6 +346,7 @@ class cfgFunctions {
 			addc(aftereject);
 			addc(hasrespirator);
 			addc(isinhouse);
+			addc(getfuzzyposition);
 			addc(isbldghostile);
 			addc(getbuildings);
 			addc(getcoveredpositions);

--- a/co30_Domination.Altis/common/fn_getfuzzyposition.sqf
+++ b/co30_Domination.Altis/common/fn_getfuzzyposition.sqf
@@ -1,0 +1,11 @@
+//by Longtime
+//#define __DEBUG__
+//#include "..\x_setup.sqf"
+
+// get a fuzzy position - take a position and return a slightly different position with randomized X and Y axis
+// useful when a building pos is already occupied but you want to place a unit anyway (but currently no collision check)
+// todo - check for collision with units, determine if inside a building and move random position toward the bldg center
+
+params ["_pos"];
+private _fuzzy_pos = [((_pos # 0) + (random 2.25 min 1.25)), ((_pos # 1) + (random 2.25 min 1.25)), _pos # 2];
+_fuzzy_pos

--- a/co30_Domination.Altis/common/fn_getfuzzyposition.sqf
+++ b/co30_Domination.Altis/common/fn_getfuzzyposition.sqf
@@ -7,5 +7,5 @@
 // todo - check for collision with units, determine if inside a building and move random position toward the bldg center
 
 params ["_pos"];
-private _fuzzy_pos = [((_pos # 0) + (random 2.25 min 1.25)), ((_pos # 1) + (random 2.25 min 1.25)), _pos # 2];
+private _fuzzy_pos = [((_pos # 0) + (random 2.5 min 1.75)), ((_pos # 1) + (random 2.5 min 1.75)), _pos # 2];
 _fuzzy_pos

--- a/co30_Domination.Altis/missions/common/fn_sidecache.sqf
+++ b/co30_Domination.Altis/missions/common/fn_sidecache.sqf
@@ -58,7 +58,7 @@ while {!_created} do {
 				private _unitstog = [
 					[[[_pos, 30]],[]] call BIS_fnc_randomPos,
 					selectRandom [3, 4, 5],			//unit count
-					-1,		//fillRadius
+					10,		//fillRadius
 					false,		//fillRoof
 					false,		//fillEvenly
 					false,		//fillTopDown

--- a/co30_Domination.Altis/missions/events/fn_event_guerrillas_embedded_as_civilians.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrillas_embedded_as_civilians.sqf
@@ -51,7 +51,7 @@ _guerrillaForce = ["allmen", "allmen", "allmen", "allmen"];
 	private _spawn_pos = selectRandom _posArray;
 	private _units = [_spawn_pos, _unitlist, _newgroup, false, true, _unitCount, opfor] call d_fnc_makemgroup;
 	_newgroup setCombatMode "BLUE";
-	private _unitsNotGarrisoned = [_spawn_pos, _units, -1, false, false, true, false, 0, true, true] call d_fnc_Zen_OccupyHouse;
+	private _unitsNotGarrisoned = [_spawn_pos, _units, 10, false, false, true, false, 0, true, true] call d_fnc_Zen_OccupyHouse;
 	{		
 		_x setSkill _guerrillaBaseSkill;
 		_x setSkill ["spotTime", 0.6];

--- a/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideevac.sqf
@@ -96,7 +96,7 @@ _pilot2 addEventHandler ["Killed", {
 [
 	([[[_poss, 35]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
 	[_pilot1],									//         2. Array of objects, the units that will garrison the building(s)
-	-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+	10,										//  (opt.) 3. Scalar, radius in which to fill building(s)
 	false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
 	false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 	true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
@@ -108,7 +108,7 @@ _pilot2 addEventHandler ["Killed", {
 [
 	([[[_poss, 35]],[]] call BIS_fnc_randomPos),											// Params: 1. Array, the building(s) nearest this position is used
 	[_pilot2],									//         2. Array of objects, the units that will garrison the building(s)
-	-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+	10,										//  (opt.) 3. Scalar, radius in which to fill building(s)
 	false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
 	false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 	true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)

--- a/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidekilltriggerman.sqf
@@ -32,7 +32,7 @@ private _tempgroup = [d_own_side] call d_fnc_creategroup;
 private _tempunit = _tempgroup createUnit [d_sm_pilottype, [0,0,0], [], 0, "NONE"];
 
 {
-	_unitsNotGarrisoned = [getPos _x, [_tempunit], -1, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
+	_unitsNotGarrisoned = [getPos _x, [_tempunit], 10, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
 	if (count _unitsNotGarrisoned == 0) exitWith {
 		// building is suitable
 		_bldg = _x;
@@ -122,7 +122,7 @@ private _enemyGuardGroup = (["specops", 0, "allmen", 1, getPos _bldg , 5, false,
 
 private _triggerman = leader _enemyGuardGroup;
 
-_unitsNotGarrisoned = [getPos _bldg, _allActors, -1, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
+_unitsNotGarrisoned = [getPos _bldg, _allActors, 10, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
 
 {
 	// log if garrison function fails

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisonerdefuse.sqf
@@ -34,7 +34,7 @@ private _tempgroup = [d_own_side] call d_fnc_creategroup;
 private _tempunit = _tempgroup createUnit [d_sm_pilottype, [0,0,0], [], 0, "NONE"];
 
 {
-	_unitsNotGarrisoned = [getPos _x, [_tempunit], -1, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
+	_unitsNotGarrisoned = [getPos _x, [_tempunit], 10, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
 	if (count _unitsNotGarrisoned == 0) exitWith {
 		// building is suitable
 		_bldg = _x;
@@ -107,7 +107,7 @@ if (d_with_dynsim == 0) then {
 
 sleep 2.333;
 
-_unitsNotGarrisoned = [getPos _bldg, _allActors, -1, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
+_unitsNotGarrisoned = [getPos _bldg, _allActors, 10, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
 
 _pilot1 setUnitPos "MIDDLE";
 

--- a/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sideprisoners.sqf
@@ -91,11 +91,11 @@ private _marker = nil;
 
 {
 	//dry run to find a suitable building
-	_unitsNotGarrisoned = [getPos _x, _allActors, -1, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
+	_unitsNotGarrisoned = [getPos _x, _allActors, 10, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
 	if (count _unitsNotGarrisoned == 0) exitWith {
 		// building is suitable
 		_bldg = _x;
-		_unitsNotGarrisoned = [getPos _x, _allActors, -1, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
+		_unitsNotGarrisoned = [getPos _x, _allActors, 10, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
 	};
 
 } forEach _buildings_array_sorted_by_distance;

--- a/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_sidevipdefend.sqf
@@ -75,11 +75,11 @@ private _bldg = nil;
 private _marker = nil;
 
 {
-	_unitsNotGarrisoned = [getPos _x, _allActors, -1, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
+	_unitsNotGarrisoned = [getPos _x, _allActors, 10, false, false, true, false, 2, true, true, true] call d_fnc_Zen_OccupyHouse; // dry run
 	if (count _unitsNotGarrisoned == 0) exitWith {
 		// building is suitable
 		_bldg = _x;
-		[getPos _x, _allActors, -1, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
+		[getPos _x, _allActors, 10, false, false, true, false, 2, true, true] call d_fnc_Zen_OccupyHouse;
 	};
 
 } forEach _buildings_array_sorted_by_distance;

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness_global.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness_global.sqf
@@ -207,7 +207,7 @@ if (_Dtargets isNotEqualTo []) then {
 				[
 					getPosATL _unit,											// Params: 1. Array, the building(s) nearest this position is used
 					units _unit,									//         2. Array of objects, the units that will garrison the building(s)
-					-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+					10,										//  (opt.) 3. Scalar, radius in which to fill building(s)
 					false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
 					true,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 					true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
@@ -223,7 +223,7 @@ if (_Dtargets isNotEqualTo []) then {
 					[
 						_startingPosition,											// Params: 1. Array, the building(s) nearest this position is used
 						units _unit,									//         2. Array of objects, the units that will garrison the building(s)
-						-1,										//  (opt.) 3. Scalar, radius in which to fill building(s), -1 for only nearest building, (default: -1)
+						10,										//  (opt.) 3. Scalar, radius in which to fill building(s)
 						false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
 						false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
 						true,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -125,7 +125,10 @@ private _placeCivilianCluster = {
     	false,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
     	false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
     	0,   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
-    	false //true                                                //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead // todo - fix the roof check, currently disqualifies many top floor position when set to true
+    	false, //true         //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead // todo - fix the roof check, currently disqualifies many top floor position when set to true
+    	true,                           //  (opt.) 10. _isAllowSpawnNearEnemy Boolean, true to allow the selected position to be near an enemy (default: false)
+    	false,                       //  (opt.) 11. _isDryRun Boolean, true to dry run, for testing only no units are moved, still returns array of units that could not be garrisoned at given pos (default: false)
+    	4.5                           //  (opt.) 12. _distanceFromBuildingCenter Scalar, distance a unit may be placed from the center of a building (usually safer) or -1 for any (default: -1)
     ] call d_fnc_Zen_OccupyHouse;	
 	
 	diag_log ["civilian cluster successfully created"];

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -61,20 +61,16 @@ private _placeCivilianCluster = {
 	if (_mustExit == true) exitWith {
 		diag_log ["unable to place civilian cluster, randomly chose a building that is too close to a mission objective"];
 	};
-	_posArray = (_bldg buildingPos -1) - d_cur_tgt_building_positions_occupied; // remove positions already used
-	_unit_count = 2 max floor(random (count _posArray));
-	if (count _posArray > 5 && {1 > random 13}) then {
+	_posArray = _bldg buildingPos -1;
+	_unit_count = 2 max floor(random 7);
+	if (count _posArray > 5 && {1 > random 9}) then {
 		// small chance for larger buildings (more than 5 positions) to have many civs
 		diag_log ["randomly chose to spawn a large civilian group"];
-		_unit_count = count _posArray - 1;
+		_unit_count = 7 max floor(random 13);
 	};
+	private _units_civ_cluster = [];
 	for "_i" from 0 to _unit_count do {
-		if (_posArray isEqualTo []) exitWith {};
-		_randomPos = selectRandom _posArray;
-		d_cur_tgt_building_positions_occupied pushBack _posArray;
-		_posArray deleteAt (_posArray find _randomPos);
-		_randomPosTerrain = [_randomPos # 0, _randomPos # 1, (_randomPos # 2) + (getTerrainHeightASL _randomPos)];
-		_civAgent = createAgent [selectRandomWeighted d_civArray, _randomPosTerrain, [], 0, "NONE"];
+		_civAgent = createAgent [selectRandomWeighted d_civArray, [0,0,0], [], 0, "NONE"];
 		_total_civs_count_created = _total_civs_count_created + 1;
 		if (random 2 <= 1) then {
 			if (random 2 <= 1) then {
@@ -117,7 +113,21 @@ private _placeCivilianCluster = {
 			};
 		}];
 		[_civAgent, selectRandom d_civ_faces] remoteExec ["setIdentity", 0, _civAgent];
+		_units_civ_cluster pushBack _civAgent;
 	};
+	
+	[
+    	getPos _bldg,											// Params: 1. Array, the building(s) nearest this position is used
+    	_units_civ_cluster,									//         2. Array of objects, the units that will garrison the building(s)
+    	10,										//  (opt.) 3. Scalar, radius in which to fill building(s)
+    	false,											//  (opt.) 4. Boolean, true to put units on the roof, false for only inside, (default: false)
+    	false,										//  (opt.) 5. Boolean, true to fill all buildings in radius evenly, false for one by one, (default: false)
+    	false,										//  (opt.) 6. Boolean, true to fill from the top of the building down, (default: false)
+    	false,									//  (opt.) 7. Boolean, true to order AI units to move to the position instead of teleporting, (default: false)
+    	0,   								//  (opt.) 8. Scalar, 0 - unit is free to move immediately (default: 0) 1 - unit is free to move after a firedNear event is triggered 2 - unit is static, no movement allowed
+    	false //true                                                //  (opt.) 9. Boolean, true to force position selection such that the unit has a roof overhead // todo - fix the roof check, currently disqualifies many top floor position when set to true
+    ] call d_fnc_Zen_OccupyHouse;	
+	
 	diag_log ["civilian cluster successfully created"];
 };
 

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -325,7 +325,7 @@ if (d_bar_mhq_destroy == 0) then {
 private _unitstog = [
 	getPos _vec,
 	3,		//unit count
-	_vec,		//fillRadius
+	10,		//fillRadius
 	true,	//fillRoof
 	false,	//fillEvenly
 	true,	//fillTopDown
@@ -659,7 +659,7 @@ if (d_occ_bldgs == 1) then {
 				false,		//fillEvenly
 				false,		//fillTopDown
 				false,		//disableTeleport
-				3		//unitMovementMode
+				3		//unitMovementMode - overwatch
 			] call d_fnc_garrisonUnits;
 			d_delinfsm append _unitstog;
 		};
@@ -696,15 +696,30 @@ if (d_occ_bldgs == 1) then {
 	diag_log [format ["creating ambush groups _amb_cnt: %1", _amb_cnt]];
 	if (_amb_cnt > 0) then {
 		for "_xx" from 0 to (_amb_cnt - 1) do {
+			private _pos = [[[_trg_center, 100]],[]] call BIS_fnc_randomPos;
+			// create an ambush group
 			private _unitstog = [
-				[[[_trg_center, 100]],[]] call BIS_fnc_randomPos,
+				_pos,
 				-1,
 				d_amb_rad,		//fillRadius
 				false,		//fillRoof
 				false,		//fillEvenly
 				false,		//fillTopDown
 				false,		//disableTeleport
-				1		//unitMovementMode
+				1		//unitMovementMode - ambush
+			] call d_fnc_garrisonUnits;
+			d_delinfsm append _unitstog;
+			
+			// create an overwatch group in same building or area (cover the ambush group)
+			private _unitstog = [
+				_pos,
+				-1,
+				d_amb_rad,		//fillRadius
+				false,		//fillRoof
+				false,		//fillEvenly
+				true,		//fillTopDown
+				false,		//disableTeleport
+				3		//unitMovementMode - overwatch
 			] call d_fnc_garrisonUnits;
 			d_delinfsm append _unitstog;
 		};
@@ -798,7 +813,7 @@ if (d_occ_bldgs == 1) then {
 			private _unitstog = [
 				getPos _x,
 				2,		//unit count
-				-1,		//fillRadius
+				5,		//fillRadius
 				true,	//fillRoof
 				false,	//fillEvenly
 				true,	//fillTopDown

--- a/co30_Domination.Altis/server/fn_garrisonUnits.sqf
+++ b/co30_Domination.Altis/server/fn_garrisonUnits.sqf
@@ -10,8 +10,7 @@ params ["_centerPos",
 	"_fillTopDown",
 	"_disableTeleport",
 	"_unitMovementMode"		// passed to zen_occupyhouse and also used in this script to determine which units to create
-							// 0 - "allmen" units with regular movement
-							// 1 - "sniper" units and cannot move
+							// if (_unitMovementMode == 2) then "sniper" else "allmen"
 ];
 
 __TRACE("from createmaintarget garrison function")
@@ -38,9 +37,10 @@ if (_unitMovementMode == 2) then {
 
 #ifndef __TT__
 private _units_to_garrison = [_centerPos, _unitlist, _newgroup, false, true, -1, d_side_player] call d_fnc_makemgroup;
+//private _units_to_garrison = ([_centerPos, _unitlist, _newgroup, false, true, -1, d_side_player] call d_fnc_makemgroup) + ([_centerPos, _unitlist, _newgroup, false, true, -1, d_side_player] call d_fnc_makemgroup);
 #else
 private _units_to_garrison = [_centerPos, _unitlist, _newgroup, false, true, -1, [blufor, opfor]] call d_fnc_makemgroup;
-#endif	
+#endif
 if (_unitMovementMode == 2) then {
 	{
 		_x disableAI "PATH";

--- a/co30_Domination.Altis/server/fn_makenewtower.sqf
+++ b/co30_Domination.Altis/server/fn_makenewtower.sqf
@@ -24,7 +24,7 @@ d_mtmissionobjs pushBack _utower;
 private _unitstog = [
 	getPos _utower,
 	3,		//unit count
-	_utower,		//fillRadius
+	5,		//fillRadius
 	true,	//fillRoof
 	true,	//fillEvenly
 	true,	//fillTopDown
@@ -36,7 +36,7 @@ d_delinfsm append _unitstog;
 _unitstog = [
 	getPos _utower,
 	5,		//unit count
-	_utower,		//fillRadius
+	5,		//fillRadius
 	false,	//fillRoof
 	false,	//fillEvenly
 	false,	//fillTopDown

--- a/co30_Domination.Altis/server/fn_serverinit.sqf
+++ b/co30_Domination.Altis/server/fn_serverinit.sqf
@@ -27,9 +27,9 @@ d_x_mt_event_types = [
 	"MARKED_FOR_DEATH",
 	"RESCUE_DEFEND",
 	"RESCUE_DEFUSE",
-	"KILL_TRIGGERMAN",
-	"CIV_RESISTANCE_INDEPENDENT",
-	"CIV_RESISTANCE_JOINPLAYER"
+	//"CIV_RESISTANCE_INDEPENDENT", // todo - broken
+	//"CIV_RESISTANCE_JOINPLAYER" // todo - broken
+	"KILL_TRIGGERMAN"
 ];
 if (d_WithLessArmor == 2 && {"GUERRILLA_TANKS" in d_x_mt_event_types}) then {d_x_mt_event_types = d_x_mt_event_types - ["GUERRILLA_TANKS"]};
 


### PR DESCRIPTION
added: civilians spawned with occupy script can be on upper floors
added: occupy script uses fuzzy positions when build positions are full
fixed: occupy script places all units in a group and does not delete units
fixed: occupy script should not use -1 radius
fixed: snipers do not spawn on roof