### PR TITLE
fixed: do not spawn civilians near enemy units

### DIFF
--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -174,11 +174,11 @@ if (_sortHeight) then {
 	} forEach _buildingPosArray;
 };
 
+diag_log [format ["placing %1 units", count _units]];
 private _unitIndex = 0;
 private _tmpPosArray = [];
 {
 	scopeName "for";
-	diag_log [format ["placing %1 units", count _units]];
 	private _posArray = _x;
 	__TRACE_2("","_building","_posArray")
 

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -187,12 +187,15 @@ private _tmpPosArray = [];
 	};
 	
 	if (_unitIndex >= count _units) exitWith {
-		//diag_log ["all units have been placed! exiting while loop."];
+		//diag_log ["all units have been placed! exiting forEach loop."];
 	};
 
 	while {count _posArray > 0} do {
 		scopeName "while";
 		__TRACE_1("","_posArray")
+		if (_unitIndex >= count _units) exitWith {
+			//diag_log ["all units have been placed! exiting while loop."];
+		};
 		private _skip_position = false;
 		private _housePosBeforeEyeHeight = _posArray select 0;
 		__TRACE_1("","_housePosBeforeEyeHeight")

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -178,20 +178,21 @@ private _unitIndex = 0;
 private _tmpPosArray = [];
 {
 	scopeName "for";
-	diag_log [format ["placing _unitIndex: %1 out of %2 units", _unitIndex, count _units]];
+	diag_log [format ["placing %1 units", count _units]];
 	private _posArray = _x;
 	__TRACE_2("","_building","_posArray")
 
 	if (count _posArray == 0) then {
 		// _posArray is empty, non-fatal but should never happen (causes the next 'while' loop to be skipped)
 	};
+	
+	if (_unitIndex >= count _units) exitWith {
+		//diag_log ["all units have been placed! exiting while loop."];
+	};
 
 	while {count _posArray > 0} do {
 		scopeName "while";
 		__TRACE_1("","_posArray")
-		if (_unitIndex >= count _units) exitWith {
-			//diag_log ["all units have been placed! exiting while loop."];
-		};
 		private _skip_position = false;
 		private _housePosBeforeEyeHeight = _posArray select 0;
 		__TRACE_1("","_housePosBeforeEyeHeight")
@@ -205,7 +206,7 @@ private _tmpPosArray = [];
 			diag_log ["position skipped, unexpectedly could not get the building object"];
 			_skip_position = true;
 		} else {
-			diag_log [ format ["bldg redetect list: %1", _bldgs_list_redetected]];
+			//diag_log [ format ["bldg redetect list: %1", _bldgs_list_redetected]];
 			_theBuilding = _bldgs_list_redetected select 0;
 		};
 		
@@ -240,7 +241,7 @@ private _tmpPosArray = [];
 								};
 	
 								if (_hitCount >= ROOF_CHECK) exitWith {
-									diag_log [format ["stopped checking steps at: %1 _hitCount equal to ROOF_CHECK: %2", _k, ROOF_CHECK]];
+									//diag_log [format ["stopped checking steps at: %1 _hitCount equal to ROOF_CHECK: %2", _k, ROOF_CHECK]];
 								};
 							};
 	

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -27,7 +27,7 @@ if (isNil "d_cur_tgt_civ_modules_presence") then {
 
 private _civ_units_count_max = 500; // default (recalculated if adaptive settings are selected)
 
-private _buildings_unfiltered = [_trg_center, _radius] call d_fnc_getbldgswithpositions;
+private _buildings_unfiltered = [_trg_center, _radius, d_side_enemy] call d_fnc_getbuildings;
 
 private _buildings = _buildings_unfiltered select { !(getModelInfo _x # 0 in d_object_spawn_civ_blacklist) };
 
@@ -164,7 +164,7 @@ if (d_civ_groupcount < 0) then {
 	if (d_civ_groupcount == -5) then {
 		_civ_spawn_factor = 0.90;  // adaptive (extreme)
 	};
-	private _bldg_count = count ([_trg_center, _radius] call d_fnc_getbldgswithpositions);
+	private _bldg_count = count ([_trg_center, _radius, d_side_enemy] call d_fnc_getbuildings);
 	private _civ_grp_count_max = floor(_civ_spawn_factor * 100); // sanity check, avoid spawning too many civ groups
 	private _civ_units_count_max = floor(_civ_grp_count_max * 3.5); // sanity check, avoid spawning too many civ units 
 	_civ_grp_count = floor (_bldg_count * _civ_spawn_factor) min _civ_grp_count_max;
@@ -177,7 +177,6 @@ for "_i" from 0 to _civ_grp_count do {
 #ifdef __DEBUG__
 	diag_log [diag_frameno, diag_ticktime, time, format ["civilian for loop, group count _i: %1", _i]];
 #endif
-	_randomPos = [[[_trg_center, 200]],[]] call BIS_fnc_randomPos;
 	_grp = createGroup [civilian, true];
 
 	__TRACE("Placing a civilian cluster...")

--- a/co30_Domination.Altis/server/fn_initvrespawn2.sqf
+++ b/co30_Domination.Altis/server/fn_initvrespawn2.sqf
@@ -19,6 +19,10 @@ d_vrespawn2_ar = [];
 		} else {
 			d_vrespawn2_ar pushBack [_vec, _number_v, _vposp, getDir _vec, typeOf _vec, _x # 2];
 			_vec setVariable ["d_vec_is_mhq", [_x # 2, _number_v]];
+			if (!d_with_ranked) then {
+				_vec setVariable ["d_ammobox", true, true];
+				_vec setVariable ["d_abox_perc", 100, true];
+			};
 		};
 		
 		_vec setVariable ["d_OUT_OF_SPACE", -1];

--- a/co30_Domination.Altis/server/fn_vrespawn2.sqf
+++ b/co30_Domination.Altis/server/fn_vrespawn2.sqf
@@ -99,6 +99,10 @@ while {true} do {
 				};
 				if (count _vec_a == 6) then {
 					_vec setVariable ["d_vec_is_mhq", [_vec_a # 5, _number_v]];
+					if (!d_with_ranked) then {
+						_vec setVariable ["d_ammobox", true, true];
+				 		_vec setVariable ["d_abox_perc", 100, true];
+					};
 				};
 				[_vec, 10] call d_fnc_setekmode;
 				_vec addEventHandler ["handleDamage", {call d_fnc_pshootatmhq}];


### PR DESCRIPTION
I wasn't using d_fnc_getbuildings to place civilians, now it checks for enemies before spawning

also removed some noisy logs