### PR TITLE
fixed: use building blacklist for enemy units as well as civilians

### DIFF
--- a/co30_Domination.Altis/common/fn_getbldgswithpositions.sqf
+++ b/co30_Domination.Altis/common/fn_getbldgswithpositions.sqf
@@ -17,7 +17,9 @@ if (_buildingsArrayRaw isEqualTo []) exitWith {
 	[]
 };
 
-private _buildingsArrayUsable = _buildingsArrayRaw select {(_x buildingPos -1) isNotEqualTo []};
+private _buildingsArrayUsableUnfiltered = _buildingsArrayRaw select {(_x buildingPos -1) isNotEqualTo []};
+
+private _buildingsArrayUsable = _buildingsArrayUsableUnfiltered select { !(getModelInfo _x # 0 in d_object_spawn_blacklist) };
 
 if (_buildingsArrayUsable isEqualTo []) exitWith {
 	[]

--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -25,6 +25,10 @@ if (hasInterface) then {
 	if (_vd > d_MaxViewDistance) then {
 		_vd = d_MaxViewDistance;
 	};
+	if (d_ViewdistanceChange == 2) then {
+		// special case, client may change later but initialize with d_InitialViewDistance
+		_vd = d_InitialViewDistance;
+	};
 	setViewDistance _vd;
 	diag_log ["DOM viewdistance at start:", _vd];
 	setObjectViewDistance (_vd + 100);

--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -384,8 +384,8 @@ if (isNil "d_mt_tower") then {
 	d_mt_tower_pos = [];
 };
 
-if (isNil "d_object_spawn_civ_blacklist") then {
-	d_object_spawn_civ_blacklist = [
+if (isNil "d_object_spawn_blacklist") then {
+	d_object_spawn_blacklist = [
 		"vn_dyke.p3d",
 		"vn_dyke_10.p3d",
 		"u_addon_01_v1_f.p3d",
@@ -400,7 +400,9 @@ if (isNil "d_object_spawn_civ_blacklist") then {
 		"i_garage_v1_f.p3d",
 		"i_garage_v2_f.p3d",
 		"cargo_house_slum_f.p3d",
-		"i_addon_02_v1_f.p3d"
+		"i_addon_02_v1_f.p3d",
+		"cargo_hq_v1_f.p3d",
+		"metal_shed_f.p3d"
 	];
 };
 

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -875,9 +875,9 @@ class Params {
 
 	class d_ViewdistanceChange {
 		title = "$STR_DOM_MISSIONSTRING_1041";
-		values[] = {0,1};
+		values[] = {0,1,2};
 		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_922","$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_VIEWDISTANCE_SERVER_INIT_CLIENT"};
 	};
 	
 	class d_AutoViewdistanceChangeDefault {

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -29,7 +29,7 @@ private _civ_units_count_max = 500; // default (recalculated if adaptive setting
 
 private _buildings_unfiltered = [_trg_center, _radius, d_side_enemy] call d_fnc_getbuildings;
 
-private _buildings = _buildings_unfiltered select { !(getModelInfo _x # 0 in d_object_spawn_civ_blacklist) };
+private _buildings = _buildings_unfiltered select { !(getModelInfo _x # 0 in d_object_spawn_blacklist) };
 
 diag_log [format ["total possible buildings to spawn civs: %1", count (_buildings)]];
 

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -42,24 +42,13 @@ private _merc_array = [
 	["East","OPF_G_F","Infantry","O_G_InfTeam_Light"] call d_fnc_GetConfigGroup
 ];
 
-#ifdef __ALTIS__
 if (d_enemy_mercenaries == 1) then {
 	d_allmen_E =+ _merc_array;
 	d_specops_E =+ _merc_array;
 	publicVariable "d_allmen_E";
 	publicVariable "d_specops_E";
-	diag_log ["Domination mercenaries configured - Altis"];
+	diag_log ["mercenaries configured for this map"];
 };
-#endif
-#ifdef __MALDEN__
-if (d_enemy_mercenaries == 1) then {
-	d_allmen_E =+ _merc_array;
-	d_specops_E =+ _merc_array;
-	publicVariable "d_allmen_E";
-	publicVariable "d_specops_E";
-	diag_log ["mercenaries configured - Malden"];
-};
-#endif
 
 private _type_list_guard = [];
 private _type_list_guard_static = [];

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -6628,12 +6628,12 @@
 <French>Distance Vue Maximale:</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1041">
-<English>Viewdistance changable:</English>
+<English>Viewdistance changeable:</English>
 <Spanish>Vista distancia variable:</Spanish>
 <Portuguese>Ver Distância variável:</Portuguese>
 <Korean>시가거리 변경 가능여부</Korean>
 <Japanese>視認距離変更可:</Japanese>
-<Original>Viewdistance changable:</Original>
+<Original>Viewdistance changeable:</Original>
 <Russian>Обзор можно изменить:</Russian>
 <Chinesesimp>调整视距：</Chinesesimp>
 <Chinese>改變視野距離:</Chinese>
@@ -14900,6 +14900,18 @@
 <Chinesesimp>Remove silencer from spawned enemy AI units:</Chinesesimp>
 <Chinese>Remove silencer from spawned enemy AI units:</Chinese>
 <French>Remove silencer from spawned enemy AI units:</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_VIEWDISTANCE_SERVER_INIT_CLIENT">
+<English>Yes (after server initializes client)</English>
+<Spanish>Yes (after server initializes client)</Spanish>
+<Portuguese>Yes (after server initializes client)</Portuguese>
+<Korean>Yes (after server initializes client)</Korean>
+<Japanese>Yes (after server initializes client)</Japanese>
+<Original>Yes (after server initializes client)</Original>
+<Russian>Yes (after server initializes client)</Russian>
+<Chinesesimp>Yes (after server initializes client)</Chinesesimp>
+<Chinese>Yes (after server initializes client)</Chinese>
+<French>Yes (after server initializes client)</French>
 </Key>
 </Container>
 </Package>


### PR DESCRIPTION
fixed: enemy unit placement now uses same blacklist for buildings as the civilian units
added: some bad buildings to the blacklist (container buildings with no doors)