### PR TITLE
only create defense and guerrilla events when d_with_MainTargetEvents is configured -3 or -4

### DIFF
--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -891,10 +891,12 @@ if (d_with_MainTargetEvents != 0) then {
 		private _tmpMtEvents = + d_x_mt_event_types;
 		if (d_with_MainTargetEvents != -3 && {d_with_MainTargetEvents != -4}) then {
 			// some events are only eligible if d_with_MainTargetEvents == -3 or -4
-			// remove ineligible events from the temp array
+			// remove ineligible events from the temp array (remove guerrilla events and shock events)
 			_tmpMtEvents deleteAt (_tmpMtEvents find "GUERRILLA_INFANTRY");
-			//_tmpMtEvents deleteAt (_tmpMtEvents find "CIV_RESISTANCE_INDEPENDENT"); // todo - fix event
-			//_tmpMtEvents deleteAt (_tmpMtEvents find "CIV_RESISTANCE_JOINPLAYER");  // todo - fix event
+			_tmpMtEvents deleteAt (_tmpMtEvents find "MARKED_FOR_DEATH");
+			_tmpMtEvents deleteAt (_tmpMtEvents find "RESCUE_DEFEND");
+			_tmpMtEvents deleteAt (_tmpMtEvents find "CIV_RESISTANCE_INDEPENDENT");
+			_tmpMtEvents deleteAt (_tmpMtEvents find "MARKED_FOR_DEATH_VIP_ESCORT");
 		};
 		if (d_with_MainTargetEvents == -2 || {d_with_MainTargetEvents == -3 || {d_with_MainTargetEvents == -4}}) then {
 			// create multiple simultaneous events

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -3051,16 +3051,16 @@
 <French>guerrillas</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_418C_GUERR">
-<English>Always, multiple events with guerrillas</English>
-<Spanish>Siempre, múltiples eventos con guerrillas</Spanish>
-<Portuguese>Always, multiple events with guerrillas</Portuguese>
+<English>Always, multiple events with guerrillas and defense</English>
+<Spanish>Siempre, múltiples eventos con guerrillas y defensar</Spanish>
+<Portuguese>Always, multiple events with guerrillas and defense</Portuguese>
 <Korean>항상, 다중 게릴라 이벤트</Korean>
 <Japanese>常時, 複数のイベント(ゲリラあり)</Japanese>
-<Original>Always, multiple events with guerrillas</Original>
-<Russian>Всегда, несколько событий with guerrillas</Russian>
+<Original>Always, multiple events with guerrillas and defense</Original>
+<Russian>Всегда, несколько событий with guerrillas and defense</Russian>
 <Chinesesimp>总是，游击队的多个事件</Chinesesimp>
 <Chinese>總是，游擊隊的多個事件</Chinese>
-<French>Always, multiple events with guerrillas</French>
+<French>Always, multiple events with guerrillas and defense</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_ALL">
 <English>All</English>


### PR DESCRIPTION
fixed: some maintarget events (guerrillas and defense events) should only be available when configured in settings