### PR TITLE
Update Params wiki page

### DIFF
--- a/Wiki_cfgparams.txt
+++ b/Wiki_cfgparams.txt
@@ -2,467 +2,157 @@
 
 ***
 
-**Available params (first description.ext/database, second server lobby):**
-#### **d_MainTargets_num / Main Targets**
-> Default: Complete, ordered (9998 in description.ext)<br/>
-> Number of main targets that will be played. Number depends on the island used<br/>
-> Complete, ordered means all targets will be used in proper sequence<br/>
-#### **d_TimeOfDay / Time of day**
-> Default: 7<br/>
-> Mission start time, available 00:00 - 23:00, 1 hour steps<br/>
-#### **d_enablefatigue / Disable fatigue:**
-> Default: 1 (No, disabled; 0 or Yes to remove fatigue)<br/>
-> If enabled (0, Yes) then players have no fatigue<br/>
-#### **d_enablesway / Disable sway:**
-> Default: 1 (No, disabled; 0 or Yes to remove sway)<br/>
-> If enabled (0, Yes) then players will have no sway<br/>
-#### **d_with_suppress / Player can be suppressed**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-#### **d_with_targetselect_count / Players can select from available targets:**
-> Default: 4<br/>
-> Number of main targets players can select next target, Entire map/9999 for all targets, Off/0 to turn off targetselect<br/>
-#### **d_targetselect_time / Target selection time:**
-> Default: 30<br/>
-> Let's you select the time players have for target selection<br/>
-> Available options: 30, 45, 60, 120, 240, 300<br/>
-#### **d_MissionType / Mission Type:**
-> Default: 0<br/>
-> Available options:<br/>
->   - Default Mission Type (0), means main targets and side missions can be played<br/>
->   - Main Targets Only (1), only main targets will spawn<br/>
->   - Side Missions Only (2), only side missions will show up<br/>
-#### **d_respawnatsql / Respawn at Squad Leader:**
-> Default: 0 (Squad Leader, enabled); 2 (Squad, enabled); 1 (None to disable); <br/>
-#### **d_retakefarps / Retake Farps**
-> Default: 0 (Yes), 1 (No) to turn it off<br/>
-> If disabled (1, No) then all Farps are available at mission start<br/>
-#### **d_with_MainTargetEvents / Main target random events:**
-> Default: 0 (Never)<br/>
-> Available options:<br/>
->   - Never (0)<br/>
->   - Low (1)<br/>
->   - Medium (2)<br/>
->   - Always (-1)<br/>
->   - Always, multiple events (-2)<br/>
-#### **d_with_ranked / Ranked:**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-> If ranked mode is enabled then players need a specific rank to have access to better weapons, to fly attack planes and choppers. Calling in for example CAS costs score and so on<br/>
-#### **d_transf_allow / Allow transfer of points to other players in ranked mode:**
-> Default: 0 (Yes), 1 (No) to turn it off<br/>
-#### **d_sm_dorandom / Random side missions:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled the order of side missions is always the same<br/>
-#### **d_bonus_vec_type / Bonus vehicles:**
-> Default: 0<br/>
-> Available options:<br/>
->   - Normal (0)<br/>
->   - No sidemission bonus vehicles (1)<br/>
->   - No main target bonus vehicles (2)<br/>
->   - No bonus vehicles at all (3)<br/>
-#### **d_ao_check_for_ai / Seize condition for main target:**
-> Attention: Only for the coop and not for the TT versions<br/>
-> Default: 1<br/>
-> Available options:<br/>
->   - All camps captured and radio tower destroyed (0)<br/>
->   - Low number of AI units, all camps captured and radio tower destroyed (1)<br/>
->   - Low number of AI units and radio tower destroyed (2)<br/>
-#### **d_mt_respawngroups / Respawn main target enemy AI groups as reinforcements:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-#### **d_bar_mhq_destroy / AO enemy barracks and vehicle MHQ has to be destroyed by explosives**
-> Default: 1 (Yes, enabled; 1 or No to disable it)<br/>
-> If set to no or 0 then you have to take barracks and vehicle MHQ like camps
-#### **d_allow_observers / Enemy AI observers for artillery and CAS at AO**
-> Default: 1 (Yes, enabled; 0 or No to disable it)<br/>
-#### **d_ai_persistent_corpses / Persistent AI corpses**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-#### **d_del_crew_always / Kill ALL vehicle crew (even outside) when a vehicle gets destroyed**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-#### **d_ao_radius_override / Target radius:**
-> Default: 0 (Normal 300m)<br/>
-> Target radius (normally 300m), available are (in meter) 350, 450, 550, 650, 750, 850 and 1000<br/>
-#### **d_save_to_mpns / Save player and mission progress to missionProfileNamespace if no SQL database is available**
-> Default: 1 (Yes, enabled; 0 or No to disable it)<br/>
-#### **d_use_systemtime / Use server system time as game time**
-> Default: 0 (No, disabled; 1 or Yes to enable it)<br/>
-> Uses server time as game start time<br/>
-#### **d_weather / Internal weather system:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-#### **d_enable_fog / Enable fog (internal weather system):**
-> Default: 0 (Yes, enables; 1 or No to disable it)<br/>
-> A3 new fog system<br/>
-#### **d_WithWinterWeather / With winter weather:**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-> If enabled (0) it adds some winter weather elemnts like different environment coloring and snow<br/>
-#### **d_withsandstorm / With sandstorm:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> Enabled on islands where it makes sense, like Altis for example<br/>
-#### **d_MaxNumAmmoboxes/ Max. number ammo boxes:**
-> Default: 10<br/>
-> Maximum number of ammo boxes which can be dropped from vehicles (loaded from ammo point at base)<br/>
-> Available values are 10, 20 and 30<br/>
-#### **d_max_truck_cargo / Engineer truck cargo capacity:**
-> Default: 6<br/>
-> Maximum number of static weapons an engineer can load into an engineer truck<br/>
-> Available values are 1, 3, 6, 9, 12 and 16<br/>
-#### **d_no_faks / Remove Fist Aid Kits:**
-> Default: 1 (No, disabled; 0 or Yes to remove FAKs)<br/>
-> Removes first aid kits, makes only sense when using it in combination with FAK revive<br/>
-#### **d_no_ai_silencer / >Remove silencer from spawned enemy AI units:**
-> Default: 0 (No, disabled; 1 or Yes to remove silencers from spawned AI units)<br/>
-#### **d_timemultiplier / Time Multiplier (1 real second = x ingame seconds):**
-> Default: 1 (disabled)<br/>
-> If a value bigger than 1 is used time will run faster<br/>
-> Available values are 1, 6, 12, 30, 45, 60, 90 and 120<br/>
-#### **d_with_dynsim / Dynamic Simulation:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If enabled the mission uses the game internal [Dynamic Simulation](https://community.bistudio.com/wiki/Arma_3_Dynamic_Simulation)<br/>
-#### **d_with_bis_dynamicgroups / With BIS Dynamic Groups (Squad Mgmt):**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If enabled the mission uses BIs [Dynamic Groups management dialog](https://community.bistudio.com/wiki/Arma_3_Dynamic_Groups)<br/>
-> It's available in the mission via Status Dialog (hold U-key to access the mission Status Dialog)<br/>
-#### **d_arsenal_mod / Use only mod weapons in [Virtual Arsenal](https://community.bistudio.com/wiki/Arma_3_Arsenal):**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If enabled and you use a [CUP version](https://github.com/Xeno69/Domination/wiki/Versions-and-needed-mods-addons#CUP) of the mission then only CUP weapons will show up in Virtual Arsenal<br/>
-#### **d_no_mortar_ar / Mortar bag packs in [Virtual Arsenal](https://community.bistudio.com/wiki/Arma_3_Arsenal):**
-> Default: 1 (No, mortar bags; 0 or Yes to add them again)<br/>
-> If set to 1/No then no mortar bags will be added to [Virtual Arsenal](https://community.bistudio.com/wiki/Arma_3_Arsenal) (0 to make mortars show again)<br/>
-#### **d_ao_markers / Turn off markers at AO for tower and camps:**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-#### **d_with_base_sabotage / With base sabotage:**
-> Default: 1 (No)<br/>
-> If set to 0 (Yes) then every now and then a group of elite soldiers will drop over your base and try to sabotage you<br/>
-#### **d_pylon_lodout / Pylon loadout enabled:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If enabled players will be able to change they [pylon loadout](https://community.bistudio.com/wiki/Arma_3_Vehicle_Loadouts) when they enter a vehicle (available via hold action menu on base)<br/>
-#### **d_pylon_noclust / Remove cluster ammo from pylon loadout**
-> Default: 0 (Yes, enabled; 1 or No to add cluster bombs again)<br/>
-> Removes cluster bombs from pylon loadout if enabled because they cause too much lag in MP<br/>
-#### **d_with_minefield / With minefield at main targets:**
-> Default: 0 (Yes, enabled; 1 or No to disable minefields)<br/>
-> Sometimes spawns a random minefield at main targets if enabled<br/>
-#### **d_va_percentage / Limit Virtual Arsenal ammo box access too 1000**
-> Default: 0 (Yes, enabled; 1 or No for no limit)<br/>
-> If enabled players can only access a dropped ammo box about 1000 times before it gets deleted<br/>
-#### **d_dis_servicep / Disable all service points, including FARPs (no refuel, no repair, no rearm, no wreck repair)**
-> Default: 1 (No; 0 or Yes to disable service points)<br/>
-#### **d_InitialViewDistance / Initial Viewdistance:**
-> Default: 1600 (meter)<br/>
-> Inital client viewdistance, available are (in meter) 1000, 1600, 2000, 3000, 3500, 4000, 4500 and 5000<br/>
-#### **d_MaxViewDistance / Maximum Viewdistance:**
-> Default: 5000 (meter)<br/>
-> Maximum viewdistance a client can select via Status Dialog. Available are (in meter) 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000 and 10000<br/>
-#### **d_ViewdistanceChange / Viewdistance changable:**
-> Default: 0 (Yes, enabled; 1 or No for no vd change; 2 for Yes after server initializes client)<br/>
-> If disabled players can not change their client viewdistance<br/>
-#### **d_AutoViewdistanceChangeDefault / Initial client setting to automatically change view distance near targets:**
-> Default: 1 (Yes, enabled; 0 or No for no automatic vd change)<br/>
-> If disabled client will default to not automatically change viewdistance but may still be enabled by the player<br/>
-#### **d_playerspectateatbase / Player can spectate other players at base flag:**
-> Default: 0 (Yes, enabled; 1 or No too disable)<br/>
-#### **d_with_airtaxi / With AI air taxi (coop version only):**
-> Default: 0 (Yes, enabled; 1 or No too disable)<br/>
-#### **d_with_airdrop / With air drop:**
-> Default: 0 (Yes, enabled; 1 or No too disable)<br/>
-#### **d_with_ai / With AI recruitment:**
-> Default: 1<br/>
-> When AI recruitment is enabled all players can mark artillery targets, call in artillery, call in a drop aircraft, call in CAS. They are also all engineers and medics. And, of course, players can recruit AI!</br>
-> Available options:<br/>
->   - Enabled (0)<br/>
->   - Disabled (1)<br/>
->   - Enabled but block recruited AI from entering static weapons (2)<br/>
->   - Enabled, but with dynamic AI recritment. Means, 1 player = d_max_ai recruitable, more players less AI recruitable, over 20 players, no AI recruitment possible (3)<br/>
->   - Enabled (4), same as 3 but block recruited AI from entering static weapons<br/>
-#### **d_with_ai_features / With AI features but no AI recruit:**
-> Default: 1 (No, disabled; 0 or Yes to enable<br/>
-> Same as d_with_ai above, just no AI recruitment<br/>
-#### **d_max_ai / Recruit AI (max.):**
-> Default: 8<br/>
-> Available options: 4, 6, 8, 10, 12, 14 and 16<br/>
-#### **d_ai_alone_in_vehicle / AI can drive vehicle without a player inside:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_ai_silent / Bots are silent**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_GrasAtStart / Grass:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled then no grass is rendered (changes terraingrid)<br/>
-#### **d_Terraindetail / Player can disable grass:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled players can not turn off grass (change terraingrid)<br/>
-#### **d_EnableSimulationCamps / Enable simulation for enemy camps:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled the simulation for object compositions at main targets is enabled (means they can be destroyed)<br/>
-#### **d_WithRevive / With revive:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled no revive is available, players can then only spawn at one of the available spawn points when they die<br/>
-#### **d_WithReviveSpectating / With revive spectating:**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> If disabled players can only see themself when they are in unconscious state<br/>
-#### **d_only_medics_canrevive / Only medics can revive:**
-> Default: 1 (disabled)<br/>
-#### **d_ACEMedicalR / Use ACE Medical Revive and not mission Revive (if ACE is available):**
-> Default: 1 (Yes, enabled; 0 or No to disable it)<br/>
-> If disabled the mission uses it's own revive instead of the ACE one<br/>
-#### **xr_max_lives / Max lives (revive):**
-> Default: 30<br/>
-> Determines how many lives a player has<br/>
-> Available options: 1, 5, 10, 20, 30, 40, 50 and Unlimited (-1)<br/>
-#### **xr_lifetime / Life time:**
-> Default: 300 (seconds)<br/>
-> Time a player stays in unconscious state if nobody revives him/her or he/she does not respawn. If the time is up the player respawns at base<br/>
-> Available options in seconds: 60, 120, 180, 240, 300, 600 and 1200<br/>
-#### **xr_respawn_available_after / Respawn possible after:**
-> Default: 5 (seconds)<br/>
-> If a player dies it takes xr_respawn_available_after seconds until he/she can respawn<br/>
-> Available options in seconds: 5, 30, 60, 90, 120, 180, 240, 300 and 600<br/>
-#### **d_with_autorevive / With auto revive if no player is nearby (less than 215m):**
-> Default: 1 (Yes; 0 or No)<br/>
-#### **d_force_fast_intro / Force fast intro:**
-> Default: 0 (Default; 1 or Yes)<br/>
-#### **d_show_playernames / Show player names:**
-> Default: 0 (Yes, enabled; 1 or No to show no player names for example above head)<br/>
-#### **d_playernames_state / Default player name state:**
-> Default: 1<br/>
-> Available options:<br/>
->   - Off (0)<br/>
->   - Names (1)<br/>
->   - Health (2)<br/>
-#### **d_show_player_marker / Player marker:**
-> Default: 1<br/>
-> Available options:<br/>
->   - Off (0)<br/>
->   - Name only (1)<br/>
->   - Marker only (2)<br/>
->   - Health (3)<br/>
-#### **d_force_isstreamfriendlyui / Force no HUD**
-> Default: 0 (No, disabled; 1 or Yes to enable it)<br/> 
-#### **d_WithAmbientRadio / With ambient radio:**
-> Default: 1 (Yes, enabled; 0 or No to disable<br/>
-#### **d_WithVoicesDisabled / Disable voices:**
-> Default: 0 (No, disabled; 1 or Yes to enable<br/>
-#### **d_with_3Dicon / With 3D draw icon above wreck repair/ammo point:**
-> Default: 1 (Yes, enabled; 0 or No to disable<br/>
-#### **d_AutoKickTime / Air vecs autokick time:**
-> Default: 1800 (seconds)<br/>
-> Autokick time means that a player who connects the first time during the mission will be kicked out of attack planes and choppers so he/she doesn't waste them<br/>
-> Available options in seconds: 0 (disabled), 60, 300, 1800 and 3600<br/>
-#### **d_score_needed_to_fly / Flying choppers and planes only allowed when a player has a score higher than:**
-> Default: 10<br/>
-> If a SQL database is available players will get kicked out of air vehicles if their score is below d_score_needed_to_fly. Doesn't affect inital choppers like MHQ/transport; can be disabled with -1 (Disabled)<br/>
-> Available options in seconds: -1 (disabled), 10, 50, 100, 500, 1000, 2000 and 5000<br/>
-#### **d_without_nvg / Without NVgoggles:**
-> Default: 1 (No, disabled; 0 or Yes to remove nv goggles)<br/>
-> If enabled removes night vision goggles from players and AI and blocks NV sights<br/>
-#### **d_without_ti / Disable Thermal Imaging (TI) for inf weapons/optics:**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-> If enabled thermal imaging for infantry weapons/optics is blocked<br/>
-#### **d_without_vec_ti / Disable vehicle TI:**
-> Default: 1 (No, disabled; 0 or Yes to remove termal imaging)<br/>
-> If enabled removes termal imaging from vehicles<br/>
-#### **d_without_vec_nvg / Disable vehicle NVG:**
-> Default: 1 (No, disabled; 0 or Yes to remove night vision)<br/>
-> If enabled removes night vision from vehicles<br/>
-#### **d_vec_at_farp / Add action menu "Spawn vehicle" to FARPs:**
-> Default: 0 (Yes, enabled; 1 or No to remove the acion menu)<br/>
-#### **d_engineerfull / Engineer full repair (old versions):**
-> Default: 1 (No, disabled; 0 or Yes to enable it)<br/>
-> If enabled an engineer has a lot more options to repair and refuel a vehicle when he has a toolkit in his bag<br/>
-#### **d_mhqvec_create_cooldown / Seconds till a player can create a new vec at MHQ:**
-> Default: 120 (seconds)<br/>
-> Available options in seconds: 0 (disabled), 60, 120, 300, 600, 1200 and 1800<br/>
-#### **d_launcher_cooldown / Launcher Cooldown Time in seconds:**
-> Default: 120 (seconds)<br/>
-> Time it takes to fire a guided launcher again (too avoid players spamming targets with missiles)<br/>
-> Available options in seconds: 0 (disabled), 60, 120, 180, 240 and 300<br/>
-#### **d_enable_extra_cas / Enable extra CAS ordnance**
-> Default: 0 (No; 1 or Yes)<br/>
-#### **d_tell_arty_cas / Always announce enemy artillery / CAS**
-> Default: 0 (No; 1 or Yes)<br/>
-#### **d_disable_player_arty / Disable player artillery**
-> Default: 0 (No, player arty is enabled; 1 or Yes to disable player arty)<br/>
-#### **d_arty_unlimited / Disable artillery cooldown**
-> Default: 0 (Default, artillery cooldown timer enabled; 1 or Yes to disable artillery cooldown timer; 2 or Low to set a low artillery cooldown timer)<br/>
-#### **d_artycheckfriendlies / Check for friendly units near artillery targets when firing artillery**
-> Default: 1 (Yes, check for friendly units; 0 or No to disable it)<br/>
-#### **d_disable_player_cas / Disable player CAS**
-> Default: 0 (No, player cas enabled; 1 or Yes to disable it)<br/>
-#### **d_show_headshots / Show headshots**
-> Default: 0 (No; 1 client only; 2 client and side chat)<br/>
-#### **d_enable_civs / Enable civilians**
-> Default: 0 (No, disabled; 1 or Yes to enable civilians)<br/>
-#### **d_civ_unitcount / Civilian unit count (walking)**
-> Default: 10<br/>
-> Available options: 10, 15, 20, 25, 30, 40, 50, 75 and 100<br/>
-#### **d_civ_groupcount / Civilian group count per target**
-> Default: 2<br/>
-> Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 and 10<br/>
-#### **d_civ_pnts / Subtract score when a player kills a civilian:**
-> Default: 3<br/>
-> Available options: 0, 1, 2, 3, 4, 5, 10, 25, 50, 75 and 100<br/>
-#### **d_enable_civ_vehs / Civilian vehicles - enabled**
-> Default: 0 (Off)<br/>
-> Available options: Off, Very Low (10), Low (25), Medium (50), High (75) and Maximum (100)<br/>
-#### **d_enable_civ_vehs_rad / Civilian vehicles - spawn radius**
-> Default: 250 (meters)<br/>
-> Available options (in meters): 150, 250, 350 and 450<br/>
-#### **d_enable_civ_vehs_locked / Civilian vehicles - lock vehicles**
-> Default: 1 (Yes, enabled; 0 or No to disable)<br/>
-#### **d_enable_extra_cas / Enable extra CAS ordnance (500lb active laser guided bomb, team shared Greyhawk combat UAV, napalm if available)**
-> Default: 0 (No, not enabled; 1 or Yes to enable it)<br/>
-#### **d_tell_arty_cas / Always announce enemy artillery / CAS**
-> Default: 0 (No, enabled; 1 or Yes to disable it)<br/>
-#### **d_disable_airai / Disable enemy air AI**
-> Default: 0 (No, air ai enabled; 1 or Yes to disable air ai)<br/>
-#### **d_occ_bldgs / Enemy AI will occupy buildings**
-> Default: 1 (Yes, enabled; 0 or No to disable)<br/>
-#### **d_ai_awareness_rad / AI Advanced - enhanced awareness (common units)**
-> Default: -1 (No)<br/>
-> Available options in meters: No (-1), 10, 25, 50, 75, 100, 150, 200, 250, 300, 400, 450, 500, 550, 600, 650, 700, 800, 900 and 1000<br/>
-#### **d_snp_aware / Garrisoned infantry sniper mode - advanced awareness**
-> Default: 0 (No, disabled; 1 or Yes to enable it)<br/>
-#### **d_ai_pursue_rad / AI Advanced - enemy active pursuit radius**
-> Default: -1 (no)<br/>
-> Available options in meters: -1 (No), 10, 25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 400, 500, 750 and 1000<br/>
-#### **d_ai_aggressiveshoot / AI Advanced - enemy shoots aggressively at players**
-> Default: 0 (No, disabled; 1 or Yes to enable it)<br/>
-#### **d_ai_quickammo / AI Advanced - enemy granted frequent ammo refills**
-> Default: 0 (No, disabled; 1 or Yes to enable it)<br/>
-#### **d_occ_cnt / Garrisoned infantry group count - occupy mode**
-> Default: 4<br/>
-> Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25 and 30<br/>
-#### **d_occ_rad / Occupy deployment radius**
-> Default: 250 (meter)<br/>
-> Available options (in meter): 125, 250 and 350<br/>
-#### **d_ovrw_cnt / Garrisoned infantry group count - overwatch mode**
-> Default: 2<br/>
-> Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25 and 30<br/>
-#### **d_ovrw_rad / Overwatch deployment radius**
-> Default: 250 (meter)<br/>
-> Available options (in meter): 125, 250 and 350<br/>
-#### **d_amb_cnt / Garrisoned infantry group count - ambush mode**
-> Default: 2<br/>
-> Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25 and 30<br/>
-#### **d_amb_rad / Ambush deployment radius**
-> Default: 250 (meter)<br/>
-> Available options (in meter): 125, 250 and 350<br/>
-#### **d_snp_cnt / Garrisoned infantry group count - sniper mode**
-> Default: 2<br/>
-> Available options: -1 (low), -2 (normal), -3 (high), -4 (very high), -5 (extreme), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30 and 45<br/>
-#### **d_snp_rad / Sniper deployment radius**
-> Default: 425 (meter)<br/>
-> Available options (in meter): 250, 425, 650 and 900<br/>
-#### **d_grp_cnt_footpatrol / Enemy infantry - patrol infantry group count**
-> Default: -1 (Default)<br/>
-> Available options: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 and 15<br/>
-#### **d_always_max_groups / Enemy infantry - always choose maximum number of groups**
-> Default: 0 (No; 1 or Yes)<br/>
-#### **d_grp_size_override / Enemy infantry - group size**
-> Default: -1 (Default)<br/>
-> Available options: 1, 2, 3, 4, 5, 6, 7, 8 and 9<br/>
-#### **d_camp_static_weapons / Defend with static weapons**
-> Default: 1 (Yes, enabled; 0 or No to disable; -1 or Random for random chance<br/>
-#### **d_camp_enable_guard / Enable guards and camps**
-> Default: 1 (No, disabled)<br/>
-> Available options: 1 (Yes, enable) and -1 (Random)<br/>
-#### **d_max_bar_cnt / Maximum number of enemy infantry barracks**
-> Default: 7<br/>
-> Available options: 1, 2, 3, 4, 5, 6, 7, 8, 9 and 10<br/>
-#### **d_max_camp_cnt / Maximum number of enemy camps to capture**
-> Default: -1<br/>
-> Available options: -1 (3-5), 1, 2, 3, 4 and 5<br/>
-#### **d_camp_center / Locate the first enemy camp to capture near the center of the main target**
-> Default: 0 (No, disabled; 1 or Yes to spawn the first camp close to the main target center)<br/>
-#### **d_WithMHQTeleport / Teleport or spawn at MHQ:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_MHQDisableNearMT / Disable MHQ if less than x m away from MT:**
-> Default: 500 (meter)<br/>
-> Available options (in meter): 0 (Off), 500, 700, 900, 1000 and 2000<br/>
-> Removes fuel from MHQ if closer than x meters away from the main target center<br/>
-#### **d_NoMHQTeleEnemyNear / No MHQ tele when enemy near:**
-> Default: 50 (meter)<br/>
-> Available options (in meter): 0 (Disabled), 50, 100, 200 and 500<br/>
-#### **d_with_mhq_camo / MHQ Camo enabled:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-> Spawns a camo net over the MHQ<br/>
-#### **d_WithTeleToBase / Enable teleport to base:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_MTTowerSatchelsOnly / MT Tower Satchels only:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-> Main target can only be destroyed by satchels if enabled<br/>
-#### **d_IllumMainTarget / Illuminate main target:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_sub_kill_points / Subtract score when a player dies:**
-> Default: 0<br/>
-> Available options: 0 (No), 1, 2, 3, 4, 5, 6, 7, 8, 9 and 10<br/>
-#### **d_pilots_only / Only pilots can fly:**
-> Default: 1 (No, disabled; 0 or Yes to enable<br/>
-> If enabled a player needs pilot headgear and pilot uniform to fly<br/>
-#### **d_WithLessArmor / Armor at main targets:**
-> Default: 0<br/>
-> Available options: 0 (Normal), 1 (Less), 2 (None) and 3 (Random)<br/>
-#### **d_WithLessArmor_side / Armor at side missions:**
-> Default: 0<br/>
-> Available options: 0 (Normal), 1 (Less) 2 (None) and 3 (Random)<br/>
-#### **d_EnemySkill / Skill Enemy:**
-> Default: 2<br/>
-> Available options: 0 (Very Low), 1 (Low), 2 (Normal), 3 (High) and 4 (Very High)<br/>
-#### **d_WithIsleDefense / With isle defense:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-> Currently completely disabled as AI driving and path finding is not a strength of the game<br/>
-#### **d_without_sm_bonus / Without sidemission bonus vehicles:**
-> Default: 1 (No, disabled; 0 or Yes for no bonus vecs)<br/>
-> If enabled no side mission bonus vehicle spawns if a side mission is resolved (see [Malden NBV version](https://github.com/Xeno69/Domination/wiki/Versions-and-needed-mods-addons#NBV) )</br>
-#### **d_smallgrps / Reduce number of AI units in groups depending on player numbers**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-> Reduces enemy AI group size depending on player numbers. Lower player number, lower group count.<br/>
-#### **d_skillfps / Adjust AI subskill if server FPS is low**
-> Default: 0 (Yes, enabled; 1 or No to disable it)<br/>
-#### **d_enemy_mercenaries / Enemy mercenaries (2035 only)**
-> Default: 0 (No; 1 or Yes)<br/>
-#### **d_ParaAtBase / Parachute from base:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_HALOWaitTime / HALO at base wait time:**
-> Default: 0<br/>
-> Available options (in seconds): 0, 300, 600, 1800 and 3600<br/>
-> Time a player has to wait till the next parajump from base<br/>
-#### **d_WithJumpFlags / No parachute jump flags:**
-> Default: 1 (No, disabled; 1 or Yes to enable<br/>
-#### **d_HALOJumpHeight / HALO jump height:**
-> Default: 2000 (meter)<br/>
-> Available options (in meter): 500, 700, 888, 1000, 2000 and 5000<br/>
-#### **d_LockArmored / Lock armored enemy armored vecs:**
-> Default: 1 (No, disabled; 0 or Yes to enable<br/>
-#### **d_LockCars / Lock armored enemy cars:**
-> Default: 1 (No, disabled; 1 or Yes to enable<br/>
-#### **d_LockAir / Lock armored enemy air vecs:**
-> Default: 1 (No, disabled; 1 or Yes to enable<br/>
-#### **d_enemy_vecs_lift / Enemy AI vehicles can be air lifted:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_maxnum_tks_forkick / Max number TKs for kick:**
-> Default: 10<br/>
-> Available options: 1, 2, 3, 5, 10, 20, 30, 40 and 1000000 (disable)<br/>
-> Starting with 4.24 players won't get kicked but put into a jail for some time<br/>
-#### **d_player_kick_shootingbase / Kick players shooting at base:**
-> Default: 10<br/>
-> Available options: 2, 3, 5, 10, 20, 30 and 1000 (No kick)<br/>
-#### **d_no_teamkill / No teamkilling possible:**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_sub_tk_points / Negative TK points:**
-> Default: 10<br/>
-> Available options: 0, 1, 5, 10, 20, 30 and 50<br/>
-> Score a player gets subtracted for killing another player<br/>
-#### **d_tk_forgive / Player can forgive teamkill (mission revive has to be enabled and spectating):**
-> Default: 0 (Yes, enabled; 1 or No to disable<br/>
-#### **d_WreckDeleteTime / Delete wrecks after:**
-> Default: 3600<br/>
-> Available options: 1800, 3600, 5400, 7200 and 1010101 (Never)<br/>
-> This is only for bonus vehicle wrecks players get when solving a side mission or a main target<br/>
-#### **d_WreckMaxRepair / Wreck max repairs:**
-> Default: 3<br/>
-> Available options: 1, 2, 3, 4, 5, 10, 20 and 10000000 (Infinite)<br/>
-> How often a bonus wreck can be repaired at the wreck point<br/>
-#### **d_drop_radius / Air drop radius:**
-> Default: 0 (meter)<br/>
-> Available options (in meter): 0 (Exact position), 10, 30, 50 and 100<br/>
-#### **d_drop_max_dist / Airdrop max. dist:**
-> Default: 500 (meter)<br/>
-> Available options (in meter): 100, 500, 1000, 2000, 5000 and 10000000 (Infinite)<br/>
+Param                           | Title                                                                                       | Default | Value: Description
+------------------------------- | ------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+d_MainTargets_num               | Main Targets                                                                                | `9998`  | `9998`: Complete, ordered <br /> `9999`: Order like placed in the editor <br /> `2`: 2 <br /> `4`: 4 <br /> `6`: 6 <br /> `8`: 8 <br /> `10`: 10 <br /> `12`: 12 <br /> `14`: 14 <br /> `16`: 16 <br /> `18`: 18 <br /> `20`: 20 <br /> `25`: 25 <br /> `34`: 34
+d_TimeOfDay                     | Time of day:                                                                                | `5`     | `0`: 00:00 <br /> `1`: 01:00 <br /> `2`: 02:00 <br /> `3`: 03:00 <br /> `4`: 04:00 <br /> `5`: 05:00 <br /> `6`: 06:00 <br /> `7`: 07:00 <br /> `8`: 08:00 <br /> `9`: 09:00 <br /> `10`: 10:00 <br /> `11`: 11:00 <br /> `12`: 12:00 <br /> `13`: 13:00 <br /> `14`: 14:00 <br /> `15`: 15:00 <br /> `16`: 16:00 <br /> `17`: 17:00 <br /> `18`: 18:00 <br /> `19`: 19:00 <br /> `20`: 20:00 <br /> `21`: 21:00 <br /> `22`: 22:00 <br /> `23`: 23:00
+d_enablefatigue                 | Disable fatigue:                                                                            | `0`     | `0`: Yes <br /> `1`: No
+d_enablesway                    | Disable sway:                                                                               | `0`     | `0`: Yes <br /> `1`: No
+d_with_suppress                 | Player can be suppressed                                                                    | `0`     | `0`: Yes <br /> `1`: No
+d_with_targetselect_count       | Players can select from available targets:                                                  | `4`     | `0`: Off <br /> `4`: 4 <br /> `8`: 8 <br /> `12`: 12 <br /> `9999`: Entire map
+d_targetselect_time             | Target selection time:                                                                      | `30`    | `30`: 30 <br /> `45`: 45 <br /> `60`: 60 <br /> `120`: 120 <br /> `240`: 240 <br /> `300`: 300
+d_MissionType                   | Mission Type:                                                                               | `0`     | `0`: Main Targets and Side Missions (Default) <br /> `1`: Main Targets Only <br /> `2`: Side Missions Only
+d_respawnatsql                  | Respawn at Squad Leader:                                                                    | `0`     | `0`: Squad Leader <br /> `2`: Squad <br /> `1`: None
+d_retakefarps                   | Retake Farps                                                                                | `0`     | `0`: Yes <br /> `1`: No
+d_with_MainTargetEvents         | Random events at main target:                                                               | `0`     | `0`: Never <br /> `1`: Low <br /> `2`: Medium <br /> `-1`: Always <br /> `-2`: Always, multiple events <br /> `-3`: Always, multiple events with guerrillas and defense <br /> `-4`: All
+d_with_ranked                   | Ranked:                                                                                     | `1`     | `0`: Yes <br /> `1`: No <br /> `2`: Ranked mode on but weapons not ranked
+d_transf_allow                  | Allow transfer of points to other players in ranked mode:                                   | `0`     | `0`: Yes <br /> `1`: No
+d_sm_dorandom                   | Random side missions:                                                                       | `0`     | `0`: Yes <br /> `1`: No
+d_bonus_vec_type                | Bonus vehicles:                                                                             | `0`     | `0`: Normal <br /> `1`: No sidemission bonus vehicles <br /> `2`: No main target bonus vehicles <br /> `3`: No bonus vehicles at all
+d_ao_check_for_ai               | Seize condition for main target:                                                            | `1`     | `0`: All camps captured and radio tower destroyed <br /> `1`: Low number of AI units, all camps captured and radio tower destroyed <br /> `2`: Low number of AI units and radio tower destroyed
+d_mt_respawngroups              | Respawn main target enemy AI groups as reinforcements:                                      | `0`     | `0`: Yes <br /> `1`: No
+d_bar_mhq_destroy               | AO enemy barracks and vehicle MHQ has to be destroyed by explosives                         | `1`     | `0`: No <br /> `1`: Yes
+d_allow_observers               | Enemy AI observers for artillery and CAS at AO                                              | `1`     | `0`: No <br /> `1`: Yes
+d_ai_persistent_corpses         | Persistent AI corpses                                                                       | `1`     | `0`: Yes <br /> `1`: No
+d_del_crew_always               | Kill ALL vehicle crew (even outside) when a vehicle gets destroyed:                         | `1`     | `0`: Yes <br /> `1`: No
+d_ao_radius_override            | Target radius:                                                                              | `0`     | `0`: Normal <br /> `350`: 350 <br /> `450`: 450 <br /> `550`: 550 <br /> `650`: 650 <br /> `750`: 750 <br /> `850`: 850 <br /> `1000`: 1000
+d_save_to_mpns                  | Save player and mission progress to missionProfileNamespace if no SQL database is available | `1`     | `0`: No <br /> `1`: Yes <br /> `2`: Yes (missionprogress autosave disabled)
+d_use_systemtime                | Use server system time as game time                                                         | `0`     | `0`: No <br /> `1`: Yes
+d_weather                       | Internal weather system:                                                                    | `0`     | `0`: Yes <br /> `1`: No
+d_enable_fog                    | Enable fog (internal weather system):                                                       | `1`     | `0`: Yes <br /> `1`: No
+d_WithWinterWeather             | With winter weather:                                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_withsandstorm                 | With sandstorm:                                                                             | `0`     | `0`: Yes <br /> `1`: No
+d_MaxNumAmmoboxes               | Max. number ammo boxes:                                                                     | `10`    | `10`: 10 <br /> `20`: 20 <br /> `30`: 30
+d_max_truck_cargo               | Engineer truck cargo capacity:                                                              | `6`     | `1`: 1 <br /> `3`: 3 <br /> `6`: 6 <br /> `9`: 9 <br /> `12`: 12 <br /> `16`: 16
+d_no_faks                       | Remove Fist Aid Kits:                                                                       | `1`     | `0`: Yes <br /> `1`: No
+d_no_ai_silencer                | Remove silencer from spawned enemy AI units:                                                | `0`     | `0`: No <br /> `1`: Yes
+d_timemultiplier                | Time Multiplier (1 real second = x ingame seconds):                                         | `1`     | `1`: Off <br /> `6`: 6 <br /> `12`: 12 <br /> `30`: 30 <br /> `45`: 45 <br /> `60`: 60 <br /> `90`: 90 <br /> `120`: 120
+d_with_dynsim                   | Dynamic Simulation:                                                                         | `0`     | `0`: Yes <br /> `1`: No
+d_with_bis_dynamicgroups        | With BIS Dynamic Groups (Squad Mgmt):                                                       | `0`     | `0`: Yes <br /> `1`: No
+d_arsenal_mod                   | Use only mod weapons in Virtual Arsenal:                                                    | `0`     | `0`: Yes <br /> `1`: No
+d_no_mortar_ar                  | Mortar bag packs in Virtual Arsenal:                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_ao_markers                    | Turn off markers at AO for tower and camps:                                                 | `1`     | `0`: Yes <br /> `1`: No
+d_with_base_sabotage            | With base sabotage:                                                                         | `1`     | `0`: Yes <br /> `1`: No
+d_pylon_lodout                  | Pylon loadout enabled:                                                                      | `0`     | `0`: Yes <br /> `1`: No
+d_pylon_noclust                 | Remove cluster ammo from pylon loadout                                                      | `0`     | `0`: Yes <br /> `1`: No
+d_with_minefield                | With minefield at main targets:                                                             | `0`     | `0`: Yes <br /> `1`: No
+d_va_percentage                 | Limit Virtual Arsenal ammo box access to 1000                                               | `0`     | `0`: Yes <br /> `1`: No
+d_dis_servicep                  | Disable all service points, including FARPs (no refuel, no repair, no rearm)                | `1`     | `0`: Yes <br /> `1`: No
+d_InitialViewDistance           | Initial Viewdistance:                                                                       | `1600`  | `1000`: 1000m <br /> `1600`: 1600m <br /> `2000`: 2000m <br /> `2500`: 2500m <br /> `3000`: 3000m <br /> `3500`: 3500m <br /> `4000`: 4000m <br /> `4500`: 4500m <br /> `5000`: 5000m
+d_MaxViewDistance               | Maximum Viewdistance:                                                                       | `5000`  | `2000`: 2000m <br /> `3000`: 3000m <br /> `4000`: 4000m <br /> `5000`: 5000m <br /> `6000`: 6000m <br /> `7000`: 7000m <br /> `8000`: 8000m <br /> `9000`: 9000m <br /> `10000`: 10000m
+d_ViewdistanceChange            | Viewdistance changeable:                                                                    | `0`     | `0`: Yes <br /> `1`: No <br /> `2`: Yes (after server initializes client)
+d_AutoViewdistanceChangeDefault | Auto viewdistance change at main target and base:                                           | `1`     | `0`: No <br /> `1`: Yes
+d_playerspectateatbase          | Player can spectate other players at base flag                                              | `0`     | `0`: Yes <br /> `1`: No
+d_with_airtaxi                  | With AI air taxi (coop version only):                                                       | `0`     | `0`: Yes <br /> `1`: No
+d_with_airdrop                  | With air drop:                                                                              | `0`     | `0`: Yes <br /> `1`: No
+d_GrasAtStart                   | Grass:                                                                                      | `0`     | `0`: Yes <br /> `1`: No
+d_Terraindetail                 | Player can disable grass:                                                                   | `0`     | `0`: Yes <br /> `1`: No
+d_EnableSimulationCamps         | Enable simulation for enemy camps:                                                          | `0`     | `1`: Yes <br /> `0`: No
+d_WithRevive                    | With revive:                                                                                | `0`     | `0`: Yes <br /> `1`: No
+d_WithReviveSpectating          | With revive spectating:                                                                     | `0`     | `0`: Yes <br /> `1`: No
+d_only_medics_canrevive         | Only medics can revive:                                                                     | `1`     | `0`: Yes <br /> `1`: No
+d_ACEMedicalR                   | Disable ACE medical revive (if ACE is used) and use mission revive                          | `1`     | `0`: Yes <br /> `1`: No
+xr_max_lives                    | Max lives (revive):                                                                         | `-1`    | `1`: 1 <br /> `5`: 5 <br /> `10`: 10 <br /> `20`: 20 <br /> `30`: 30 <br /> `40`: 40 <br /> `50`: 50 <br /> `-1`: Unlimited
+xr_lifetime                     | Life time:                                                                                  | `300`   | `60`: 60 secs <br /> `120`: 120 secs <br /> `180`: 180 secs <br /> `240`: 240 secs <br /> `300`: 300 secs <br /> `600`: 600 secs <br /> `1200`: 1200 secs
+xr_respawn_available_after      | Respawn possible after:                                                                     | `5`     | `5`: 5 secs <br /> `30`: 30 secs <br /> `60`: 60 secs <br /> `90`: 90 secs <br /> `120`: 120 secs <br /> `180`: 180 secs <br /> `240`: 240 secs <br /> `300`: 300 secs <br /> `600`: 600 secs
+d_with_autorevive               | With auto revive if no player is nearby (less than 215m):                                   | `1`     | `0`: Yes <br /> `1`: No
+d_force_fast_intro              | Force fast intro:                                                                           | `0`     | `0`: Default <br /> `1`: Yes
+d_show_playernames              | Show player names:                                                                          | `0`     | `0`: Over head <br /> `1`: Cursor target
+d_playernames_state             | Default player name state:                                                                  | `1`     | `0`: Off <br /> `1`: Names <br /> `2`: Health
+d_show_player_marker            | Player marker:                                                                              | `1`     | `0`: Off <br /> `1`: Name only <br /> `2`: Marker only <br /> `3`: Health
+d_force_isstreamfriendlyui      | Force no HUD                                                                                | `0`     | `0`: No <br /> `1`: Yes
+d_show_headshots                | Show headshots                                                                              | `0`     | `0`: No <br /> `1`: Client only <br /> `3`: Client and allies
+d_WithAmbientRadio              | With ambient radio:                                                                         | `1`     | `0`: No <br /> `1`: Yes
+d_WithVoicesDisabled            | Disable voices:                                                                             | `0`     | `0`: No <br /> `1`: Yes
+d_with_3Dicon                   | With 3D draw icon above wreck repair/ammo point:                                            | `1`     | `0`: No <br /> `1`: Yes
+d_AutoKickTime                  | Air vecs autokick time:                                                                     | `1800`  | `0`: 0 Minutes <br /> `60`: 1 Minute <br /> `300`: 5 Minutes <br /> `600`: 10 Minutes <br /> `1800`: 30 Minutes <br /> `3600`: 60 Minutes
+d_score_needed_to_fly           | Flying choppers and planes only allowed when a player has a score higher than:              | `10`    | `-1`: Disabled <br /> `10`: 10 <br /> `50`: 50 <br /> `100`: 100 <br /> `500`: 500 <br /> `1000`: 1000 <br /> `2000`: 2000 <br /> `5000`: 5000
+d_without_nvg                   | Without NVgoggles:                                                                          | `1`     | `0`: Yes <br /> `1`: No <br /> `2`: Block but not for missile launchers
+d_without_ti                    | Disable Thermal Imaging (TI) for inf weapons/optics:                                        | `1`     | `0`: Yes <br /> `1`: No <br /> `2`: Block but not for missile launchers
+d_without_vec_ti                | Disable vehicle TI:                                                                         | `1`     | `0`: Yes <br /> `1`: No
+d_without_vec_nvg               | Disable vehicle NVG:                                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_vec_at_farp                   | Add action menu "Spawn vehicle" to FARPs:                                                   | `0`     | `0`: Yes <br /> `1`: No
+d_engineerfull                  | Engineer full repair (old versions):                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_mhqvec_create_cooldown        | Seconds till a player can create a new vec at MHQ:                                          | `120`   | `0`: Off <br /> `60`: 60 <br /> `120`: 120 <br /> `300`: 300 <br /> `600`: 600 <br /> `1200`: 1200 <br /> `1800`: 1800
+d_launcher_cooldown             | Launcher Cooldown Time in seconds:                                                          | `120`   | `0`: Off <br /> `60`: 60 <br /> `120`: 120 <br /> `180`: 180 <br /> `240`: 240 <br /> `300`: 300
+d_enable_extra_cas              | Enable extra CAS ordnance                                                                   | `0`     | `0`: No <br /> `1`: Yes
+d_tell_arty_cas                 | Always announce enemy artillery / CAS                                                       | `0`     | `0`: No <br /> `1`: Yes
+d_disable_player_arty           | Disable player artillery                                                                    | `0`     | `0`: No <br /> `1`: Yes
+d_arty_unlimited                | Disable artillery and CAS cooldown                                                          | `0`     | `0`: Default <br /> `1`: Disabled <br /> `2`: Low
+d_artycheckfriendlies           | Check for friendly units near artillery targets when firing artillery                       | `1`     | `0`: No <br /> `1`: Yes
+d_disable_player_cas            | Disable player CAS                                                                          | `0`     | `0`: No <br /> `1`: Yes
+d_enable_civs                   | Civilians - enable civilians                                                                | `0`     | `0`: Off <br /> `1`: On
+d_civ_unitcount                 | Civilians - civilian unit count (walking)                                                   | `10`    | `10`: 10 <br /> `15`: 15 <br /> `20`: 20 <br /> `25`: 25 <br /> `30`: 30 <br /> `40`: 40 <br /> `50`: 50 <br /> `75`: 75 <br /> `100`: 100
+d_civ_groupcount                | Civilians - civilian group count per target                                                 | `10`    | `-1`: Low <br /> `-2`: Normal <br /> `-3`: High <br /> `-4`: Very High <br /> `-5`: Extreme <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `15`: 15 <br /> `20`: 20 <br /> `25`: 25 <br /> `30`: 30 <br /> `35`: 35 <br /> `40`: 40 <br /> `45`: 45 <br /> `50`: 50 <br /> `75`: 75 <br /> `100`: 100 <br /> `150`: 150 <br /> `200`: 200 <br /> `250`: 250 <br /> `300`: 300
+d_civ_pnts                      | Civilians - subtract score when a player kills a civilian:                                  | `3`     | `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `10`: 10 <br /> `25`: 25 <br /> `50`: 50 <br /> `75`: 75 <br /> `100`: 100
+d_enable_civ_vehs               | Civilian vehicles - enabled                                                                 | `0`     | `0`: Off <br /> `10`: VeryLow <br /> `25`: Low <br /> `50`: Medium <br /> `75`: High <br /> `100`: Maximum
+d_enable_civ_vehs_rad           | Civilian vehicles - spawn radius                                                            | `250`   | `150`: 150m <br /> `250`: 250m <br /> `350`: 350m <br /> `450`: 450m
+d_enable_civ_vehs_locked        | Civilian vehicles - lock vehicles                                                           | `1`     | `0`: No <br /> `1`: Yes
+d_disable_airai                 | Disable enemy air                                                                           | `0`     | `0`: No <br /> `1`: Yes
+d_occ_bldgs                     | Enemy AI will occupy buildings                                                              | `1`     | `0`: No <br /> `1`: Yes
+d_ai_awareness_rad              | AI Advanced - enhanced awareness (common units)                                             | `-1`    | `-1`: No <br /> `10`: 10m <br /> `25`: 25m <br /> `50`: 50m <br /> `75`: 75m <br /> `100`: 100m <br /> `150`: 150m <br /> `200`: 200m <br /> `250`: 250m <br /> `300`: 300m <br /> `400`: 400m <br /> `450`: 450m <br /> `500`: 500m <br /> `550`: 550m <br /> `600`: 600m <br /> `650`: 650m(recommended) <br /> `700`: 700m <br /> `800`: 800m <br /> `900`: 900m <br /> `1000`: 1000m
+d_snp_aware                     | AI Advanced - enhanced awareness (sniper units)                                             | `0`     | `0`: No <br /> `1`: Yes
+d_ai_pursue_rad                 | AI Advanced - enemy active pursuit radius                                                   | `-1`    | `-1`: No <br /> `10`: 10m <br /> `25`: 25m <br /> `50`: 50m <br /> `75`: 75m <br /> `100`: 100m <br /> `125`: 125m <br /> `150`: 150m(recommended) <br /> `175`: 175m <br /> `200`: 200m <br /> `225`: 225m <br /> `250`: 250m <br /> `275`: 275m <br /> `300`: 300m <br /> `400`: 400m <br /> `500`: 500m <br /> `750`: 750m <br /> `1000`: 1000m
+d_ai_aggressiveshoot            | AI Advanced - enemy shoots aggressively at players                                          | `0`     | `0`: No <br /> `1`: Yes
+d_ai_quickammo                  | AI Advanced - enemy granted frequent ammo refills                                           | `0`     | `0`: No <br /> `1`: Yes
+d_occ_cnt                       | Enemy infantry - garrisoned group count - occupy mode                                       | `4`     | `-1`: Low <br /> `-2`: Normal <br /> `-3`: High <br /> `-4`: Very High <br /> `-5`: Extreme <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `11`: 11 <br /> `12`: 12 <br /> `13`: 13 <br /> `14`: 14 <br /> `15`: 15 <br /> `16`: 16 <br /> `17`: 17 <br /> `18`: 18 <br /> `19`: 19 <br /> `20`: 20 <br /> `21`: 21 <br /> `22`: 22 <br /> `23`: 23 <br /> `24`: 24 <br /> `25`: 25 <br /> `30`: 30 <br /> `35`: 35 <br /> `40`: 40 <br /> `45`: 45 <br /> `50`: 50
+d_occ_rad                       | Enemy infantry - deployment radius                                                          | `250`   | `125`: 125m <br /> `250`: 250m <br /> `350`: 350m <br /> `450`: 450m <br /> `550`: 550m <br /> `650`: 650m <br /> `750`: 750m <br /> `1000`: 1000m
+d_ovrw_cnt                      | Enemy infantry - garrisoned infantry group count - overwatch mode                           | `2`     | `-1`: Low <br /> `-2`: Normal <br /> `-3`: High <br /> `-4`: Very High <br /> `-5`: Extreme <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `11`: 11 <br /> `12`: 12 <br /> `13`: 13 <br /> `14`: 14 <br /> `15`: 15 <br /> `16`: 16 <br /> `17`: 17 <br /> `18`: 18 <br /> `19`: 19 <br /> `20`: 20 <br /> `21`: 21 <br /> `22`: 22 <br /> `23`: 23 <br /> `24`: 24 <br /> `25`: 25 <br /> `30`: 30 <br /> `35`: 35 <br /> `40`: 40 <br /> `45`: 45 <br /> `50`: 50
+d_ovrw_rad                      | Enemy infantry - deployment radius                                                          | `250`   | `125`: 125m <br /> `250`: 250m <br /> `350`: 350m <br /> `450`: 450m <br /> `550`: 550m <br /> `650`: 650m <br /> `750`: 750m <br /> `1000`: 1000m
+d_amb_cnt                       | Enemy infantry - garrisoned infantry group count - ambush mode                              | `2`     | `-1`: Low <br /> `-2`: Normal <br /> `-3`: High <br /> `-4`: Very High <br /> `-5`: Extreme <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `11`: 11 <br /> `12`: 12 <br /> `13`: 13 <br /> `14`: 14 <br /> `15`: 15 <br /> `16`: 16 <br /> `17`: 17 <br /> `18`: 18 <br /> `19`: 19 <br /> `20`: 20 <br /> `21`: 21 <br /> `22`: 22 <br /> `23`: 23 <br /> `24`: 24 <br /> `25`: 25 <br /> `30`: 30 <br /> `35`: 35 <br /> `40`: 40 <br /> `45`: 45 <br /> `50`: 50
+d_amb_rad                       | Enemy infantry - deployment radius                                                          | `250`   | `75`: 75m <br /> `125`: 125m <br /> `250`: 250m <br /> `300`: 300m <br /> `350`: 350m <br /> `450`: 450m <br /> `550`: 550m <br /> `650`: 650m <br /> `750`: 750m <br /> `1000`: 1000m
+d_snp_cnt                       | Enemy infantry - garrisoned infantry group count - sniper mode                              | `2`     | `-1`: Low <br /> `-2`: Normal <br /> `-3`: High <br /> `-4`: Very High <br /> `-5`: Extreme <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `15`: 15 <br /> `20`: 20 <br /> `25`: 25 <br /> `30`: 30 <br /> `45`: 45 <br /> `50`: 50
+d_snp_rad                       | Enemy infantry - deployment radius                                                          | `425`   | `250`: 250m <br /> `425`: 425m <br /> `650`: 650m <br /> `900`: 900m
+d_grp_cnt_footpatrol            | Enemy infantry - patrol infantry group count                                                | `-1`    | `-1`: Default <br /> `0`: 0 <br /> `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10 <br /> `11`: 11 <br /> `12`: 12 <br /> `13`: 13 <br /> `14`: 14 <br /> `15`: 15
+d_always_max_groups             | Enemy infantry - always choose maximum number of groups                                     | `0`     | `0`: No <br /> `1`: Yes
+d_grp_size_override             | Enemy infantry - group size                                                                 | `0`     | `0`: Default <br /> `1`: High
+d_camp_static_weapons           | Defend with static weapons                                                                  | `1`     | `0`: No <br /> `1`: Yes <br /> `-1`: Random
+d_camp_enable_guard             | Enable guards and camps                                                                     | `1`     | `0`: No <br /> `1`: Yes <br /> `-1`: Random
+d_max_bar_cnt                   | Maximum number of enemy infantry barracks                                                   | `7`     | `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `6`: 6 <br /> `7`: 7 <br /> `8`: 8 <br /> `9`: 9 <br /> `10`: 10
+d_max_camp_cnt                  | Maximum number of enemy camps to capture                                                    | `-1`    | `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `-1`: 3to5
+d_camp_center                   | Locate the first enemy camp to capture near the center of the main target                   | `0`     | `0`: No <br /> `1`: Yes
+d_WithMHQTeleport               | Teleport or spawn at MHQ:                                                                   | `0`     | `0`: Yes <br /> `1`: No
+d_MHQDisableNearMT              | Disable MHQ if less than x m away from MT:                                                  | `500`   | `0`: Off <br /> `500`: 500m <br /> `700`: 700m <br /> `900`: 900m <br /> `1000`: 1000m <br /> `2000`: 2000m
+d_NoMHQTeleEnemyNear            | No MHQ tele when enemy near:                                                                | `50`    | `0`: Disabled <br /> `50`: 50m <br /> `100`: 100m <br /> `200`: 200m <br /> `500`: 500m
+d_with_mhq_camo                 | MHQ Camo enabled:                                                                           | `0`     | `0`: Yes <br /> `1`: No
+d_WithTeleToBase                | Enable teleport to base:                                                                    | `0`     | `0`: Yes <br /> `1`: No
+d_MTTowerSatchelsOnly           | MT Tower Satchels only:                                                                     | `0`     | `0`: Yes <br /> `1`: No
+d_IllumMainTarget               | Illuminate main target:                                                                     | `0`     | `0`: Yes <br /> `1`: No
+d_sub_kill_points               | Subtract score when a player dies:                                                          | `0`     | `0`: No <br /> `1`: -1 Points <br /> `2`: -2 Points <br /> `3`: -3 Points <br /> `4`: -4 Points <br /> `5`: -5 Points <br /> `6`: -6 Points <br /> `7`: -7 Points <br /> `8`: -8 Points <br /> `9`: -9 Points <br /> `10`: -10 Points
+d_pilots_only                   | Only pilots can fly:                                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_WithLessArmor                 | Armor at main targets:                                                                      | `0`     | `0`: Normal <br /> `1`: Less <br /> `2`: None <br /> `3`: Random
+d_WithLessArmor_side            | Armor at side missions:                                                                     | `0`     | `0`: Normal <br /> `1`: Less <br /> `2`: None <br /> `3`: Random
+d_EnemySkill                    | Skill Enemy:                                                                                | `2`     | `0`: Very Low <br /> `1`: Low <br /> `2`: Normal <br /> `3`: High <br /> `4`: Very High
+d_WithIsleDefense               | With isle defense:                                                                          | `0`     | `0`: Yes <br /> `1`: No
+d_without_sm_bonus              | Without sidemission bonus vehicles:                                                         | `1`     | `0`: Yes <br /> `1`: No
+d_smallgrps                     | Reduce number of AI units in groups depending on player numbers                             | `0`     | `0`: Yes <br /> `1`: No
+d_skillfps                      | Adjust AI subskill if server FPS is low                                                     | `0`     | `0`: Yes <br /> `1`: No
+d_enemy_mercenaries             | Enemy mercenaries (2035 only)                                                               | `0`     | `0`: No <br /> `1`: Yes
+d_enemy_factions                | MODS REQUIRED - Enemy factions (experimental)                                               | `0`     | `0`: Default <br /> `1`: Taliban (Community Factions Project) <br /> `2`: Asian Insurgents (Asian Factions for CUP) <br /> `3`: Central African Rebels (Community Factions Project) <br /> `4`: Islamic State (Community Factions Project) <br /> `5`: Sudanese Armed Forces (Community Factions Project)
+d_ParaAtBase                    | Parachute from base:                                                                        | `0`     | `0`: Yes <br /> `1`: No
+d_HALOWaitTime                  | HALO at base wait time:                                                                     | `0`     | `0`: 0 Minutes <br /> `300`: 5 Minutes <br /> `600`: 10 Minutes <br /> `1800`: 30 Minutes <br /> `3600`: 60 Minutes
+d_WithJumpFlags                 | No parachute jump flags:                                                                    | `1`     | `0`: Yes <br /> `1`: No
+d_HALOJumpHeight                | HALO jump height:                                                                           | `2000`  | `500`: 500m <br /> `700`: 700m <br /> `888`: 888m <br /> `1000`: 1000m <br /> `2000`: 2000m <br /> `5000`: 5000m
+d_LockArmored                   | Lock armored enemy vecs:                                                                    | `1`     | `0`: Yes <br /> `1`: No
+d_LockCars                      | Lock enemy cars:                                                                            | `1`     | `0`: Yes <br /> `1`: No
+d_LockAir                       | Lock enemy air vecs:                                                                        | `1`     | `0`: Yes <br /> `1`: No
+d_enemy_vecs_lift               | Enemy AI vehicles can be air lifted:                                                        | `0`     | `0`: Yes <br /> `1`: No
+d_maxnum_tks_forkick            | Max number TKs for kick:                                                                    | `10`    | `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `5`: 5 <br /> `10`: 10 <br /> `20`: 20 <br /> `30`: 30 <br /> `40`: 40 <br /> `1000000`: Disable
+d_player_kick_shootingbase      | Kick players shooting at base:                                                              | `10`    | `2`: 2 Shots <br /> `3`: 3 Shots <br /> `5`: 5 Shots <br /> `10`: 10 Shots <br /> `20`: 20 Shots <br /> `30`: 30 Shots <br /> `1000`: No kick
+d_no_teamkill                   | No teamkilling possible:                                                                    | `1`     | `0`: Yes <br /> `1`: No
+d_sub_tk_points                 | Negative TK points:                                                                         | `10`    | `0`: 0 <br /> `1`: 1 <br /> `5`: 5 <br /> `10`: 10 <br /> `20`: 20 <br /> `30`: 30 <br /> `50`: 50
+d_tk_forgive                    | Player can forgive teamkill (mission revive has to be enabled and spectating):              | `0`     | `0`: Yes <br /> `1`: No
+d_WreckDeleteTime               | Delete wrecks after:                                                                        | `3600`  | `1800`: 30 minutes <br /> `3600`: 60 minutes <br /> `5400`: 90 minutes <br /> `7200`: 120 minutes <br /> `1010101`: Never
+d_WreckMaxRepair                | Wreck max repairs:                                                                          | `3`     | `1`: 1 <br /> `2`: 2 <br /> `3`: 3 <br /> `4`: 4 <br /> `5`: 5 <br /> `10`: 10 <br /> `20`: 20 <br /> `10000000`: Infinite
+d_drop_radius                   | Air drop radius:                                                                            | `0`     | `0`: Exact position <br /> `10`: 10m <br /> `30`: 30m <br /> `50`: 50m <br /> `100`: 100m
+d_drop_max_dist                 | Airdrop max. dist:                                                                          | `500`   | `100`: 100m <br /> `500`: 500m <br /> `1000`: 1000m <br /> `2000`: 2000m <br /> `3000`: 3000m <br /> `5000`: 5000m <br /> `10000000`: Infinite


### PR DESCRIPTION
If you'd like to see the rendered result, I've added a wiki page in my fork of the domination repo which you can view [here](https://github.com/PurplProto/Domination/wiki/Params).

The motivation behind this PR is that I found a few parameters listed with incorrect values, so I wrote a quick script to parse the `description.ext` and substitute all the variables there with the values from `stringtable.xml`. If you'd like to use the script in the future, feel free to do so. I've made it publicly available [here](https://github.com/PurplProto/Xeno69-Domination-params-parser).

It might also be worth noting where there were multiple default values depending on the mission, I took the ones in the `__ALTIS__` conditional block.