### PR TITLE
new "preemptive" event type and events

### DIFF
--- a/co30_Domination.Altis/bikb/domkba3.bikb
+++ b/co30_Domination.Altis/bikb/domkba3.bikb
@@ -421,11 +421,6 @@ class Sentences {
 			class 1 {type = "simple";};
 		};
 	};
-	class MTEventSideEnemyAttackFail {
-		text = "$STR_DOM_MISSIONSTRING_FAIL_ENEMY_BREACH";
-		speech[] = {};
-		class Arguments {};
-	};
 	class MTEventSideRabbitRescue {
 		text = "$STR_DOM_MISSIONSTRING_2028_RABBIT";
 		speech[] = {};

--- a/co30_Domination.Altis/bikb/domkba3.bikb
+++ b/co30_Domination.Altis/bikb/domkba3.bikb
@@ -414,6 +414,18 @@ class Sentences {
 			class 1 {type = "simple";};
 		};
 	};
+	class MTEventSideEnemyAttack {
+		text = "$STR_DOM_MISSIONSTRING_2028_ENEMY_ATTACK";
+		speech[] = {};
+		class Arguments {
+			class 1 {type = "simple";};
+		};
+	};
+	class MTEventSideEnemyAttackFail {
+		text = "$STR_DOM_MISSIONSTRING_FAIL_ENEMY_BREACH";
+		speech[] = {};
+		class Arguments {};
+	};
 	class MTEventSideRabbitRescue {
 		text = "$STR_DOM_MISSIONSTRING_2028_RABBIT";
 		speech[] = {};

--- a/co30_Domination.Altis/cfgfunctions.hpp
+++ b/co30_Domination.Altis/cfgfunctions.hpp
@@ -483,6 +483,7 @@ class cfgFunctions {
 			addc(event_sidekilltriggerman);
 			addc(event_civ_massacre);
 			addc(event_guerrillas_embedded_as_civilians);
+			addc(event_enemy_incoming);
 		};
 		class Dom_Server {
 			file = "server";

--- a/co30_Domination.Altis/clientui/fn_checkpjumppos.sqf
+++ b/co30_Domination.Altis/clientui/fn_checkpjumppos.sqf
@@ -4,7 +4,7 @@
 
 disableSerialization;
 
-if (d_cur_tgt_pos isEqualTo []) exitWith {true};
+if (d_cur_tgt_pos isEqualTo [] || d_preemptive_special_event) exitWith {true};
 
 private _res = (_this # 0) distance2D d_cur_tgt_pos > d_cur_target_radius + 200;
 

--- a/co30_Domination.Altis/clientui/fn_mapondraw.sqf
+++ b/co30_Domination.Altis/clientui/fn_mapondraw.sqf
@@ -171,3 +171,20 @@ private _marker_vecs = d_marker_vecs;
 		};
 	};
 } forEach _marker_vecs select {!isNull _x};
+
+/*
+diag_log ["foooooooooo"];
+diag_log [d_preemptive_special_event];
+diag_log [d_cur_tgt_pos];
+diag_log [d_preemptive_special_event_startpos];
+diag_log ["fooooooooooend"];
+
+if (d_preemptive_special_event && {d_cur_tgt_pos isNotEqualTo [] && {d_preemptive_special_event_startpos isNotEqualTo []}}) then {
+	diag_log ["foooooooooodraw"];
+	_map drawArrow [
+		d_preemptive_special_event_startpos,
+		d_cur_tgt_pos,
+		[1,0,0,1]
+	];
+};
+*/

--- a/co30_Domination.Altis/clientui/fn_mapondraw.sqf
+++ b/co30_Domination.Altis/clientui/fn_mapondraw.sqf
@@ -171,20 +171,3 @@ private _marker_vecs = d_marker_vecs;
 		};
 	};
 } forEach _marker_vecs select {!isNull _x};
-
-/*
-diag_log ["foooooooooo"];
-diag_log [d_preemptive_special_event];
-diag_log [d_cur_tgt_pos];
-diag_log [d_preemptive_special_event_startpos];
-diag_log ["fooooooooooend"];
-
-if (d_preemptive_special_event && {d_cur_tgt_pos isNotEqualTo [] && {d_preemptive_special_event_startpos isNotEqualTo []}}) then {
-	diag_log ["foooooooooodraw"];
-	_map drawArrow [
-		d_preemptive_special_event_startpos,
-		d_cur_tgt_pos,
-		[1,0,0,1]
-	];
-};
-*/

--- a/co30_Domination.Altis/d_init.sqf
+++ b/co30_Domination.Altis/d_init.sqf
@@ -381,6 +381,12 @@ if (isNil "d_priority_targets") then {
 if (isNil "d_civ_massacre") then {
 	d_civ_massacre = false;
 };
+if (isNil "d_preemptive_special_event") then {
+	d_preemptive_special_event = false;
+};
+if (isNil "d_preemptive_special_event_startpos") then {
+	d_preemptive_special_event_startpos = [];
+};
 if (isNil "d_cur_tgt_civ_vehicles") then {
 	d_cur_tgt_civ_vehicles = [];
 };

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -3384,7 +3384,10 @@ if (d_enemy_factions > 0) then {
 				#include "d_veh_a_O_faction1-taliban.sqf"
 			];
 			d_veh_a_W =+ d_veh_a_E;
-			d_allmen_E = [["EAST","CFP_O_TBAN","Infantry","CFP_O_TBAN_infantry_8man_team"] call d_fnc_GetConfigGroup];
+			d_allmen_E = [
+				["EAST","CFP_O_TBAN","Infantry","CFP_O_TBAN_infantry_8man_team"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
+			];
 			d_specops_E = [["EAST","CFP_O_TBAN","SpecOps","CFP_O_TBAN_infantry_sniper_team"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","CFP_O_TBAN","SpecOps","CFP_O_TBAN_infantry_sniper_team"] call d_fnc_GetConfigGroup];
 			d_faction_independent_array = [["WEST","CFP_B_AFARMY","Infantry","cfp_b_afarmy_infantry_squad"] call d_fnc_GetConfigGroup];
@@ -3397,6 +3400,7 @@ if (d_enemy_factions > 0) then {
 			d_allmen_E = [
 				["EAST","CUP_INS_ASIA","Infantry","cupinsasia_infantry_8man_team_a"] call d_fnc_GetConfigGroup,
 				["EAST","CUP_INS_ASIA","Infantry","cupinsasia_infantry_8man_team_b"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
 			];
 			d_specops_E = [["EAST","CUP_INS_ASIA","Infantry","cupinsasia_infantry_2man_team_b"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","CUP_INS_ASIA","Infantry","cupinsasia_infantry_2man_team_b"] call d_fnc_GetConfigGroup];
@@ -3407,7 +3411,10 @@ if (d_enemy_factions > 0) then {
 				#include "d_veh_a_O_faction3-centralafrica.sqf"
 			];
 			d_veh_a_W =+ d_veh_a_E;
-			d_allmen_E = [["East","CFP_O_CFRebels","Infantry","cfp_o_cfrebels_infantry_squad"] call d_fnc_GetConfigGroup];
+			d_allmen_E = [
+				["East","CFP_O_CFRebels","Infantry","cfp_o_cfrebels_infantry_squad"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
+			];
 			d_specops_E = [["East","CFP_O_CFRebels","SpecOps","cfp_o_cfrebels_specops_ex_military_fireteam"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["East","CFP_O_CFRebels","SpecOps","o_cfpocfrebels_specops_sniper_team"] call d_fnc_GetConfigGroup];
 			d_faction_independent_array = [["Indep","CFP_I_SSArmy","Infantry","CFP_I_SSArmy_infantry_squad"] call d_fnc_GetConfigGroup];
@@ -3421,6 +3428,7 @@ if (d_enemy_factions > 0) then {
 			d_specops_E = [
 				["EAST","CFP_O_IS","Infantry","cfp_o_grp_is_wpn_squad"] call d_fnc_GetConfigGroup,
 				["EAST","CFP_O_IS","Infantry","cfp_o_grp_is_hq_squad"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
 			];
 			//d_sniper_E = // no sniper class
 			d_faction_independent_array = [["WEST","CFP_B_IQARMY","Infantry","cfp_b_grp_ia_inf_squad"] call d_fnc_GetConfigGroup];
@@ -3433,6 +3441,7 @@ if (d_enemy_factions > 0) then {
 			d_allmen_E = [
 				["EAST","CFP_O_SDARMY","Infantry","CFP_O_SDARMY_infantry_squad"] call d_fnc_GetConfigGroup,
 				["EAST","CFP_O_SDARMY","Infantry","CFP_O_SDARMY_infantry_riot_squad"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
 			];
 			d_specops_E = [["EAST","CFP_O_SDARMY","SpecOps","CFP_O_SDARMY_specops_paratrooper_squad"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","CFP_O_SDARMY","SpecOps","CFP_O_SDARMY_infantry_sniper_team"] call d_fnc_GetConfigGroup];
@@ -3447,6 +3456,7 @@ if (d_enemy_factions > 0) then {
 				["EAST","CFP_O_RUARMY_DES","Infantry","cfp_o_ruarmy_infantry_msv_infantry_squad_emr_des"] call d_fnc_GetConfigGroup,
 				["EAST","CFP_O_RUARMY_DES","Infantry","cfp_o_ruarmy_infantry_vdv_infantry_squad_emr_des"] call d_fnc_GetConfigGroup,
 				["EAST","CFP_O_RUARMY_DES","Infantry","InfSquad_DES"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
 			];
 			d_specops_E = [["EAST","CFP_O_RUARMY_DES","SpecOps","cfp_o_ruarmy_specops_spetsnaz_team_des"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","CFP_O_RUARMY_DES","Infantry","cfp_o_ruarmy_infantry_msv_sniper_team_emr_des"] call d_fnc_GetConfigGroup];
@@ -3460,6 +3470,7 @@ if (d_enemy_factions > 0) then {
 			d_allmen_E = [
 				["EAST","RWR_ru_winter","RWR_ru_infantry_winter","RWR_group_inf_group"] call d_fnc_GetConfigGroup,
 				["EAST","RWR_ru_winter","RWR_ru_infantry_winter","RWR_group_inf_groupmg"] call d_fnc_GetConfigGroup
+				// TODO add an AT group
 			];
 			d_specops_E = [["EAST","RWR_ru_winter","RWR_ru_infantry_winter","RWR_group_inf_groupmg"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","RWR_ru_winter","RWR_ru_infantry_winter","RWR_group_inf_teamdm"] call d_fnc_GetConfigGroup];
@@ -3473,7 +3484,8 @@ if (d_enemy_factions > 0) then {
 			d_veh_a_W =+ d_veh_a_E;
 			d_allmen_E = [
 				["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_RIF_Squad"] call d_fnc_GetConfigGroup,
-				["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_AR_ISL_Squad"] call d_fnc_GetConfigGroup
+				["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_AR_ISL_Squad"] call d_fnc_GetConfigGroup,
+				["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_AT_Squad"] call d_fnc_GetConfigGroup
 			];
 			d_specops_E = [["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_RIF_Squad"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","UK3CB_ADG_O","Infantry","UK3CB_ADG_O_MK_Sentry"] call d_fnc_GetConfigGroup];
@@ -3488,9 +3500,8 @@ if (d_enemy_factions > 0) then {
 			d_allmen_E = [
 				["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_AR_Squad"] call d_fnc_GetConfigGroup,
 				["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_MG_Squad"] call d_fnc_GetConfigGroup,
-				["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_RIF_Squad"] call d_fnc_GetConfigGroup
-				// UK3CB_ION_O_Urban_AT_Squad
-				// 
+				["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_RIF_Squad"] call d_fnc_GetConfigGroup,
+				["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_AT_Squad"] call d_fnc_GetConfigGroup
 			];
 			d_specops_E = [["EAST","UK3CB_ION_O_Urban","SpecOps","UK3CB_ION_O_Urban_DEM_SpecTeam"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [["EAST","UK3CB_ION_O_Urban","Infantry","UK3CB_ION_O_Urban_MK_Sentry"] call d_fnc_GetConfigGroup];
@@ -3505,9 +3516,8 @@ if (d_enemy_factions > 0) then {
 			d_allmen_E = [
 				["EAST","UK3CB_KRG_O","Infantry","UK3CB_KRG_O_AR_Squad"] call d_fnc_GetConfigGroup,
 				["EAST","UK3CB_KRG_O","Infantry","UK3CB_KRG_O_MG_Squad"] call d_fnc_GetConfigGroup,
-				["EAST","UK3CB_KRG_O","Infantry","UK3CB_KRG_O_RIF_Squad"] call d_fnc_GetConfigGroup
-				// UK3CB_ION_O_Urban_AT_Squad
-				// 
+				["EAST","UK3CB_KRG_O","Infantry","UK3CB_KRG_O_RIF_Squad"] call d_fnc_GetConfigGroup,
+				["EAST","UK3CB_KRG_O","Infantry","UK3CB_KRG_O_AT_Squad"] call d_fnc_GetConfigGroup
 			];
 			d_specops_E = [["EAST","UK3CB_KRG_O","SpecOps","UK3CB_KRG_O_Recon_SpecSquad"] call d_fnc_GetConfigGroup];
 			d_sniper_E = [

--- a/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
@@ -1,0 +1,246 @@
+// by Longtime
+//#define __DEBUG__
+#include "..\..\x_setup.sqf"
+
+#ifdef __TT__
+//do not run this event in TvT (for now)
+if (true) exitWith {};
+#endif
+
+// Protect an unconscious pilot somewhere in the maintarget, enemy spawned nearby will attack the pilot
+// Defense only, no enemy will spawn in the maintarget
+
+if !(isServer) exitWith {};
+
+params ["_target_radius", "_target_center"];
+
+private _mt_event_key = format ["d_X_MTEVENT_%1", d_cur_tgt_name];
+
+private _townNearbyName = "";
+private _townNearbyPos = [];
+private _minimumDistanceFromMaintarget = 325;
+private _maximumDistanceFromMaintarget = 400;
+private _marker = nil;
+
+private _towns = nearestLocations [_target_center, ["NameCityCapital", "NameCity", "NameVillage"], 10000];
+
+// find a town outside the minimum distance
+{
+	if (_target_center distance2D getPos _x > _minimumDistanceFromMaintarget) exitWith {
+		_townNearbyPos = getPos _x;
+		_townNearbyName = text _x;
+	};
+} forEach _towns;
+
+if (_townNearbyPos isEqualTo []) exitWith {
+	diag_log ["unable to find a location to spawn infantry for guerrilla mission event", d_cur_tgt_name];
+};
+
+private _x_mt_event_ar = [];
+
+private _trigger = [_target_center, [d_cur_target_radius,d_cur_target_radius,0,false,30], ["ANYPLAYER","PRESENT",true], ["this","thisTrigger setVariable ['d_event_start', true]",""]] call d_fnc_CreateTriggerLocal;
+
+private _eventDescription = format [localize "STR_DOM_MISSIONSTRING_2028_INFANTRY", _townNearbyName];
+d_mt_event_messages_array pushBack _eventDescription;
+publicVariable "d_mt_event_messages_array";
+
+d_kb_logic1 kbTell [
+	d_kb_logic2,
+	d_kb_topic_side,
+	"MTEventSideEnemyAttack",
+	["1", "", _townNearbyName, []],
+	d_kbtel_chan
+];
+
+// TODO - wait or make the players move quickly?
+//waitUntil {sleep 0.1; !isNil {_trigger getVariable "d_event_start"}};
+
+private _spawn_pos = _townNearbyPos;
+
+if (_target_center distance2D _townNearbyPos > _maximumDistanceFromMaintarget) then {
+	// try to find a midpoint between chosen location and maintarget, too far for infantry to walk from location to location
+	private _midpoint_pos = [
+		((_target_center # 0) + (_townNearbyPos # 0))/2,
+		((_target_center # 1) + (_townNearbyPos # 1))/2
+	];
+	if ((_midpoint_pos distance2D _target_center) > _minimumDistanceFromMaintarget) then {
+		// if midpoint is not too close then use it instead of _townNearbyPos
+		_spawn_pos = _midpoint_pos;
+	};
+};
+
+d_preemptive_special_event_startpos = _spawn_pos;
+publicVariable "d_preemptive_special_event_startpos";
+
+private _newgroups = [];
+// calculate the sum of all groups of AI already in the maintarget and size the enemy force accordingly
+private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt;
+// default guerrilla force
+private _enemyForceInf = ["allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen"];
+private _enemyForceVeh = ["jeep_mg"];
+if (_targetGroupCount > 10) then {
+	_enemyForceInf = ["allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen"];
+	_enemyForceVeh = ["jeep_mg", "wheeled_apc"];
+};
+if (_targetGroupCount > 20) then {
+	_enemyForceInf = ["allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen", "allmen"];
+	_enemyForceVeh = ["jeep_mg", "wheeled_apc", "tracked_apc"];
+};
+
+{
+	private _unitlist = [_x, d_enemy_side_short] call d_fnc_getunitlistm;
+	private _newgroup = [d_side_enemy] call d_fnc_creategroup;
+	private _units = [_spawn_pos, _unitlist, _newgroup, false, true] call d_fnc_makemgroup;
+	{
+		//_x setSkill _guerrillaBaseSkill;
+		//_x setSkill ["spotTime", 0.6];
+		//_x setSkill ["spotDistance", 0.6];
+		_x setSkill ["courage", 1];
+		_x setSkill ["commanding", 1];
+		_x_mt_event_ar pushBack _x;
+	} forEach _units;
+	_newgroups pushBack _newgroup;
+	if (d_with_dynsim == 0) then {
+		[_newgroup, 0] spawn d_fnc_enabledynsim;
+	};
+} forEach _enemyForceInf;
+
+private _vdir = _target_center getDir _spawn_pos;
+{
+	private _unitlist = [_x, d_enemy_side_short] call d_fnc_getunitlistv;
+	private _newgroup = [d_side_enemy] call d_fnc_creategroup;
+	private _units = [1, _spawn_pos, _unitlist, _newgroup, _vdir, true, true, true] call d_fnc_makevgroup;
+	_newgroups pushBack _newgroup;
+	if (d_with_dynsim == 0) then {
+		[_newgroup, 0] spawn d_fnc_enabledynsim;
+	};
+} forEach _enemyForceVeh;
+
+sleep 3.14;
+
+
+
+
+/*
+private _poss = [[[_target_center, (d_cur_target_radius * 0.85)]],[[_target_center, (d_cur_target_radius * 0.40)]]] call BIS_fnc_randomPos;
+private _nposss = _poss findEmptyPosition [0, 25, d_sm_pilottype];
+if (_nposss isEqualTo []) then {_nposss = _poss};
+
+private _rescueGroup = [d_own_side] call d_fnc_creategroup;
+
+// create pilot1
+private _pilot1 = _rescueGroup createUnit [d_sm_pilottype, _nposss, [], 0, "NONE"];
+[_pilot1, 75] call d_fnc_nodamoffdyn;
+__TRACE_1("","_pilot1")
+_pilot1 call d_fnc_removenvgoggles_fak;
+removeHeadgear _pilot1;
+_pilot1 unlinkItem (hmd _pilot1); //remove nvgs
+[_pilot1, getPos _pilot1] call d_fnc_setposagls;
+
+removeAllWeapons _pilot1;
+_pilot1 setCaptive true;
+_pilot1 enableStamina false;
+_pilot1 enableFatigue false;
+_pilot1 disableAI "PATH";
+_pilot1 disableAI "RADIOPROTOCOL";
+_pilot1 forceSpeed 0;
+(leader _rescueGroup) setSkill 1;
+_rescueGroup allowFleeing 0;
+_rescueGroup deleteGroupWhenEmpty true;
+
+
+if (d_with_dynsim == 0) then {
+	[_rescueGroup] spawn d_fnc_enabledynsim;
+};
+
+// pilot cannot move for the entire event
+_pilot1 setUnconscious true;
+
+private _eventDescription = localize "STR_DOM_MISSIONSTRING_DEFEND";
+_marker_def = ["d_mt_event_enemy_incoming", getPos _pilot1, "ICON","ColorBlack", [1, 1], _eventDescription, 0, "mil_triangle"] call d_fnc_CreateMarkerGlobal;
+[_marker_def, "STR_DOM_MISSIONSTRING_DEFEND"] remoteExecCall ["d_fnc_setmatxtloc", [0, -2] select isDedicated];
+
+// actually don't immediately target the pilot, allow the players 90 seconds to set up a defense
+//sleep 90;
+sleep 10;
+
+// now the attack begins
+d_priority_targets pushBack _pilot1;
+publicVariable "d_priority_targets";
+*/
+
+
+
+
+sleep 2.333;
+
+{
+	_x setCombatMode "RED";
+	_x setSpeedMode "FULL";
+	_x setBehaviour "CARELESS";
+	_wp = _x addWaypoint[getPos _pilot1, 0];
+	_wp setWaypointBehaviour "SAFE";
+	_wp setWaypointSpeed "FULL";
+	_wp setwaypointtype "SAD";
+	_wp setWaypointFormation "STAG COLUMN";
+} forEach _newgroups;
+
+_marker_enemy_spawn = ["d_mt_event_marker_enemyincoming", _spawn_pos, "ICON","ColorBlack", [1, 1], localize "STR_DOM_MISSIONSTRING_964", 0, "mil_start"] call d_fnc_CreateMarkerGlobal;
+[_marker_enemy_spawn, "STR_DOM_MISSIONSTRING_964"] remoteExecCall ["d_fnc_setmatxtloc", [0, -2] select isDedicated];
+
+private _event_start_time = time;
+private _event_survive_time = 10*60; // 10 minutes
+//private _failed = false;
+
+//while {sleep 15; (time - _start_time) < _duration;} do {
+	//private _foundAlive = _newgroups findIf {(units _x) findIf {alive _x} > -1} > -1;
+	//if (!_foundAlive) exitWith {};
+	// mission failed if enemies are within 25m of target center
+	//if ({ side _x == d_side_enemy } count nearestObjects [_target_center, ["Man","Car","Tank"], 25] > 0) exitWith { _failed = true; };
+//};
+
+// waitUntil either killed EH or _event_survive_time duration
+waitUntil {sleep 3;!(_pilot1 in d_priority_targets) || {(time - _event_start_time) > _event_survive_time}};
+
+diag_log ["enemy_incoming ended"];
+
+sleep 5;
+
+//if (_failed) then {
+if (!(_pilot1 in d_priority_targets)) then {	
+	d_kb_logic1 kbTell [d_kb_logic2,d_kb_topic_side,"MTEventSideEnemyAttackFail",d_kbtel_chan];
+} else {
+	private _event_succeed_points = 20;
+	d_kb_logic1 kbTell [
+    	d_kb_logic2,
+    	d_kb_topic_side,
+    	"EventSucceed",
+    	["1", "", str _event_succeed_points, []],
+    	d_kbtel_chan
+    ];
+    {
+    	_x addScore _event_succeed_points;
+    } forEach (allPlayers - entities "HeadlessClient_F");
+};
+
+d_mt_event_messages_array deleteAt (d_mt_event_messages_array find _eventDescription);
+publicVariable "d_mt_event_messages_array";
+
+deleteVehicle _trigger;
+deleteMarker _marker_def;
+deleteMarker _marker_enemy_spawn;
+
+d_preemptive_special_event = false;
+publicVariable "d_preemptive_special_event";
+d_preemptive_special_event_startpos = [];
+publicVariable "d_preemptive_special_event_startpos";
+
+
+if (d_ai_persistent_corpses == 0) then {
+	waitUntil {sleep 10; d_mt_done};
+} else {
+	sleep 120;
+};
+
+//cleanup
+//_x_mt_event_ar call d_fnc_deletearrayunitsvehicles;

--- a/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
@@ -112,9 +112,6 @@ if (d_WithLessArmor == 4) then {
 	private _newgroup = [d_side_enemy] call d_fnc_creategroup;
 	private _units = [_spawn_pos, _unitlist, _newgroup, false, true] call d_fnc_makemgroup;
 	{
-		//_x setSkill _guerrillaBaseSkill;
-		//_x setSkill ["spotTime", 0.6];
-		//_x setSkill ["spotDistance", 0.6];
 		_x setSkill ["courage", 1];
 		_x setSkill ["commanding", 1];
 		_x_mt_event_ar pushBack _x;
@@ -153,8 +150,6 @@ sleep 60;
 	_wp setwaypointtype "SAD";
 	_wp setWaypointFormation "STAG COLUMN";
 } forEach _newgroups;
-
-//d_mt_radio_down = true; // radiotower create was skipped //////////////////////////////
 
 waitUntil {sleep 3; d_mt_done};
 

--- a/co30_Domination.Altis/missions/events/fn_event_tanksincoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_tanksincoming.sqf
@@ -41,6 +41,7 @@ private _with_less_armor = if (!isNil "d_enemy_mode_current_maintarget") then {
 };
 
 switch (_with_less_armor) do {
+	// normal
 	case 0: {
 		_eventArmorAll = [
 			_eventArmorMedium,
@@ -48,14 +49,24 @@ switch (_with_less_armor) do {
 			_eventArmorLight
 		];
 	};
+	// low
 	case 1: {
 		_eventArmorAll = [
 			_eventArmorMedium,
 			_eventArmorLight
 		];	
 	};
+	// none
 	case 2: {
 		_eventArmorAll = [
+			_eventArmorLight
+		];
+	};
+	// high
+	case 4: {
+		_eventArmorAll = [
+			_eventArmorHeavy,
+			_eventArmorMedium,
 			_eventArmorLight,
 			_eventArmorLight
 		];

--- a/co30_Domination.Altis/server/fn_createsecondary.sqf
+++ b/co30_Domination.Altis/server/fn_createsecondary.sqf
@@ -10,7 +10,9 @@ params ["_wp_array", "_mtradius", "_trg_center"];
 
 sleep 1.120;
 
-_this call d_fnc_getmtmission;
+if (!d_preemptive_special_event) then {
+	_this call d_fnc_getmtmission;
+};
 
 sleep 1.0123;
 
@@ -104,7 +106,10 @@ if (d_with_dynsim == 0) then {
 #endif
 sleep 1.0112;
 
-["specops", [_poss], _trg_center, 0, "guard", d_enemy_side_short, 0, -1.111, 1, [_trg_center, _mtradius]] call d_fnc_makegroup;
+if (!d_preemptive_special_event) then {
+	// no specops when a special event is already running
+	["specops", [_poss], _trg_center, 0, "guard", d_enemy_side_short, 0, -1.111, 1, [_trg_center, _mtradius]] call d_fnc_makegroup;
+};
 
 #ifndef __TT__
 sleep 1;
@@ -253,6 +258,7 @@ if (d_ao_check_for_ai in [0, 1]) then {
 		sleep 0.5;
 
 		if (_wf distance2D _trg_center > d_cur_target_radius || {random 100 > 30}) then {
+			if (d_preemptive_special_event) exitWith {}; // no secondary when a special event is already running
 			private _retgr = ["specops", [_poss], _trg_center, 0, "guard", d_enemy_side_short, 0, -1.111, 1, [_trg_center, _mtradius]] call d_fnc_makegroup;
 			(_retgr # 1) spawn {
 				scriptname "spawn 5_createsecondary";

--- a/co30_Domination.Altis/server/fn_delstuff.sqf
+++ b/co30_Domination.Altis/server/fn_delstuff.sqf
@@ -26,7 +26,7 @@ params ["_idx", "_mt_barracks_obj_ar", "_bara_trig_ar", "_mt_mobile_hq_obj", "_m
 	deleteVehicle _x;
 } forEach (_bara_trig_ar select {!isNull _x});
 
-if (!isNull _mt_mobile_hq_obj) then {
+if (!isNil "_mt_mobile_hq_obj" && {!isNull _mt_mobile_hq_obj}) then {
 	_mt_mobile_hq_obj spawn {
 		scriptName "spawn doexechcf2";
 		sleep (60 + random 60);

--- a/co30_Domination.Altis/server/fn_makenewtower.sqf
+++ b/co30_Domination.Altis/server/fn_makenewtower.sqf
@@ -21,28 +21,30 @@ _utower addEventhandler ["Killed", {call d_fnc_utowerkilled}];
 d_mtmissionobjs pushBack _vec;
 d_mtmissionobjs pushBack _utower;
 
-private _unitstog = [
-	getPos _utower,
-	3,		//unit count
-	5,		//fillRadius
-	true,	//fillRoof
-	true,	//fillEvenly
-	true,	//fillTopDown
-	false,	//disableTeleport
-	0		//unitMovementMode
-] call d_fnc_garrisonUnits;
-d_delinfsm append _unitstog;
+if (!d_preemptive_special_event) then {
+	private _unitstog = [
+		getPos _utower,
+		3,		//unit count
+		5,		//fillRadius
+		true,	//fillRoof
+		true,	//fillEvenly
+		true,	//fillTopDown
+		false,	//disableTeleport
+		0		//unitMovementMode
+	] call d_fnc_garrisonUnits;
+	d_delinfsm append _unitstog;
+	
+	_unitstog = [
+		getPos _utower,
+		5,		//unit count
+		5,		//fillRadius
+		false,	//fillRoof
+		false,	//fillEvenly
+		false,	//fillTopDown
+		false,	//disableTeleport
+		0		//unitMovementMode
+	] call d_fnc_garrisonUnits;
+	d_delinfsm append _unitstog;
+};
 
-_unitstog = [
-	getPos _utower,
-	5,		//unit count
-	5,		//fillRadius
-	false,	//fillRoof
-	false,	//fillEvenly
-	false,	//fillTopDown
-	false,	//disableTeleport
-	0		//unitMovementMode
-] call d_fnc_garrisonUnits;
-d_delinfsm append _unitstog;
- 
 _vec

--- a/co30_Domination.Altis/server/fn_setenemymode.sqf
+++ b/co30_Domination.Altis/server/fn_setenemymode.sqf
@@ -7,7 +7,7 @@
 //   0 Normal
 //   1 Less
 //   2 None
-//   3 Random, enemy mode is randomly chosen [0,1,2] each time a maintarget is created
+//   3 Random, enemy mode is randomly chosen [0,1,2,4] each time a maintarget is created
 //   4 High
 
 __TRACE_1("","_this")

--- a/co30_Domination.Altis/server/fn_target_clear.sqf
+++ b/co30_Domination.Altis/server/fn_target_clear.sqf
@@ -35,7 +35,7 @@ if (d_bar_mhq_destroy == 0) then {
 {
 	_x setVariable ["d_mt_done", true];
 } forEach (d_mt_barracks_obj_ar select {alive _x});
-if (alive d_mt_mobile_hq_obj) then {
+if (!isNil "d_mt_mobile_hq_obj" && {alive d_mt_mobile_hq_obj}) then {
 	d_mt_mobile_hq_obj setVariable ["d_mt_done", true];
 };
 d_mt_done = true;
@@ -44,7 +44,7 @@ publicVariable "d_mt_done";
 sleep 0.01;
 
 if (!d_side_main_done) then {
-	if (alive d_fixor_var) then {
+	if (!isNil "d_fixor_var" && {alive d_fixor_var}) then {
 		d_fixor_var setDamage 1;
 	};
 	d_side_main_done = true;
@@ -174,6 +174,9 @@ if (d_maintargets_list isNotEqualTo []) then {
 	};
 	private _mtunits =+ d_delinfsm;
 	d_delinfsm = [];
+	if (isNil "d_mt_mobile_hq_obj") then {
+		d_mt_mobile_hq_obj = objNull;
+	};
 	[d_current_target_index, _mt_barracks_obj_ar, _bara_trig_ar, d_mt_mobile_hq_obj, _mines_created, _mtunits] spawn d_fnc_delstuff;
 };
 

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -14097,6 +14097,18 @@
 <Chinese>注意：游擊隊已從 %1 遷入該城市。游擊隊對藍方友好，對紅方敵對。</Chinese>
 <French>Attention: Guerrilla infantry units are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_2028_ENEMY_ATTACK">
+<English>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</English>
+<Spanish>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Spanish>
+<Portuguese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Portuguese>
+<Korean>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Korean>
+<Japanese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Japanese>
+<Original>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Original>
+<Russian>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Russian>
+<Chinesesimp>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Chinesesimp>
+<Chinese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Chinese>
+<French>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_RESISTANCE">
 <English>Attention: some of the civilians are armed and ready to fight!</English>
 <Spanish>Attention: some of the civilians are armed and ready to fight!</Spanish>
@@ -14264,6 +14276,18 @@
 <Chinesesimp>敌人引爆了一个装置。失败！</Chinesesimp>
 <Chinese>敵人引爆了一個裝置。失敗！</Chinese>
 <French>The enemy detonated a device. Failure.</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_FAIL_ENEMY_BREACH">
+<English>The enemy breached the safezone. Mission failed.</English>
+<Spanish>The enemy breached the safezone. Mission failed.</Spanish>
+<Portuguese>The enemy breached the safezone. Mission failed.</Portuguese>
+<Korean>The enemy breached the safezone. Mission failed.</Korean>
+<Japanese>The enemy breached the safezone. Mission failed.</Japanese>
+<Original>The enemy breached the safezone. Mission failed.</Original>
+<Russian>The enemy breached the safezone. Mission failed.</Russian>
+<Chinesesimp>The enemy breached the safezone. Mission failed.</Chinesesimp>
+<Chinese>The enemy breached the safezone. Mission failed.</Chinese>
+<French>The enemy breached the safezone. Mission failed.</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_EXPLOSIVES_SUCCESS">
 <English>Enemy explosive device disabled.</English>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -14098,16 +14098,16 @@
 <French>Attention: Guerrilla infantry units are moving into the city from %1. The guerrillas are friendly to Blufor and hostile to Opfor.</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_2028_ENEMY_ATTACK">
-<English>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</English>
-<Spanish>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Spanish>
-<Portuguese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Portuguese>
-<Korean>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Korean>
-<Japanese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Japanese>
-<Original>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Original>
-<Russian>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Russian>
-<Chinesesimp>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Chinesesimp>
-<Chinese>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</Chinese>
-<French>Attention: Enemy units are moving into the city from %1. Defend the city! If any enemies reach the city center then the mission is a failure.</French>
+<English>Attention: Enemy units are moving into the city from %1. Defend the city!</English>
+<Spanish>Attention: Enemy units are moving into the city from %1. Defend the city!</Spanish>
+<Portuguese>Attention: Enemy units are moving into the city from %1. Defend the city!</Portuguese>
+<Korean>Attention: Enemy units are moving into the city from %1. Defend the city!</Korean>
+<Japanese>Attention: Enemy units are moving into the city from %1. Defend the city!</Japanese>
+<Original>Attention: Enemy units are moving into the city from %1. Defend the city!</Original>
+<Russian>Attention: Enemy units are moving into the city from %1. Defend the city!</Russian>
+<Chinesesimp>Attention: Enemy units are moving into the city from %1. Defend the city!</Chinesesimp>
+<Chinese>Attention: Enemy units are moving into the city from %1. Defend the city!</Chinese>
+<French>Attention: Enemy units are moving into the city from %1. Defend the city!</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_RESISTANCE">
 <English>Attention: some of the civilians are armed and ready to fight!</English>

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -14277,18 +14277,6 @@
 <Chinese>敵人引爆了一個裝置。失敗！</Chinese>
 <French>The enemy detonated a device. Failure.</French>
 </Key>
-<Key ID="STR_DOM_MISSIONSTRING_FAIL_ENEMY_BREACH">
-<English>The enemy breached the safezone. Mission failed.</English>
-<Spanish>The enemy breached the safezone. Mission failed.</Spanish>
-<Portuguese>The enemy breached the safezone. Mission failed.</Portuguese>
-<Korean>The enemy breached the safezone. Mission failed.</Korean>
-<Japanese>The enemy breached the safezone. Mission failed.</Japanese>
-<Original>The enemy breached the safezone. Mission failed.</Original>
-<Russian>The enemy breached the safezone. Mission failed.</Russian>
-<Chinesesimp>The enemy breached the safezone. Mission failed.</Chinesesimp>
-<Chinese>The enemy breached the safezone. Mission failed.</Chinese>
-<French>The enemy breached the safezone. Mission failed.</French>
-</Key>
 <Key ID="STR_DOM_MISSIONSTRING_EXPLOSIVES_SUCCESS">
 <English>Enemy explosive device disabled.</English>
 <Spanish>Enemy explosive device disabled.</Spanish>


### PR DESCRIPTION
new events will be available if the server is configured for "events with guerrilas"

a preemptive event may be randomly selected (10% chance) then 50/50 chance the event will be a) opfor vs indfor or b) opfor only

if preemptive event is selected:

* do not create enemies inside the maintarget 
* create tower and hq camps but no units or vehicles
* start event - create opfor units and vehicles in a nearby location
* start event - existing guerrila event in nearby location at opposite side of maintarget
* opfor and indfor will wait for 60 seconds and then march into town and fight each other
* players may parajump in the target during this event
* victory condition for mt_done is forced to "low AI" so players must clear out the enemy