### PR TITLE
CUP Takistan civs, walking civs may be disabled, preemptive event tuning, etc

### DIFF
--- a/Wiki_cfgparams.txt
+++ b/Wiki_cfgparams.txt
@@ -1334,6 +1334,18 @@
 >    - 2000m (2000) <br />
 >    - 5000m (5000) <br />
 
+#### **d_force_steerable_parachutes / Force steerable parachutes for players:**
+> Default: 0 - No <br />
+> Available options: <br />
+>    - Yes (1) <br />
+>    - No (0) <br />
+
+#### **d_paradrop_no_restrictions / Players may parajump to any location:**
+> Default: 0 - No <br />
+> Available options: <br />
+>    - Yes (1) <br />
+>    - No (0) <br />
+
 #### **d_LockArmored / Lock armored enemy vecs:**
 > Default: 1 - No <br />
 > Available options: <br />

--- a/co30_Domination.Altis/client/fn_bike.sqf
+++ b/co30_Domination.Altis/client/fn_bike.sqf
@@ -56,7 +56,9 @@ if (d_with_ranked || {d_database_found}) then {
 	[player, 3] remoteExecCall ["d_fnc_ascfc", 2];
 };
 
-systemChat format [localize "STR_DOM_MISSIONSTRING_161", _disp_name];
+if (!isStreamFriendlyUIEnabled && {d_force_isstreamfriendlyui != 1}) then {
+	systemChat format [localize "STR_DOM_MISSIONSTRING_161", _disp_name];
+};
 sleep 3.123;
 player setVariable ["d_bike_b_mode", _b_mode];
 private _vet = if (_b_mode == 1) then {-1} else {

--- a/co30_Domination.Altis/client/fn_makeuav_combat.sqf
+++ b/co30_Domination.Altis/client/fn_makeuav_combat.sqf
@@ -42,10 +42,7 @@ if !(d_UAV_Terminal in (assignedItems player)) then {
 	player linkItem d_UAV_Terminal;
 };
 
-private _uav = [getPosATL player, 0, d_UAV_CAS, d_player_side, false, false] call bis_fnc_spawnVehicle;
-// force the UAV to desired altitude
-private _temppos = getPosWorld (_uav # 0);
-(_uav # 0) setPosATL [_temppos # 0, _temppos # 1, 2000];
+private _uav = [[(getPosATL player) # 0, (getPosATL player) # 1, 2000], 0, d_UAV_CAS, d_player_side, false, false] call bis_fnc_spawnVehicle;
 
 __TRACE_1("","_uav")
 _uav params ["_vecu", "_crew", "_grp"];

--- a/co30_Domination.Altis/client/fn_pjump.sqf
+++ b/co30_Domination.Altis/client/fn_pjump.sqf
@@ -16,7 +16,7 @@ if (d_with_ai && {d_player_canu}) then {[getPosATL player, velocity player, getD
 
 d_jump_action_id = player addAction [localize "str_a3_rscgrouprootmenu_items_openparachute0", {
 	private _chuten = call {
-		if (d_ifa3 || {d_gmcwg || {d_unsung || {d_csla || {d_vn}}}}) exitWith {
+		if (d_ifa3 || {d_gmcwg || {d_unsung || {d_csla || {d_vn && {d_force_steerable_parachutes != 1}}}}}) exitWith {
 			d_non_steer_para
 		};
 		"Steerable_Parachute_F"

--- a/co30_Domination.Altis/clientui/fn_checkpjumppos.sqf
+++ b/co30_Domination.Altis/clientui/fn_checkpjumppos.sqf
@@ -4,7 +4,7 @@
 
 disableSerialization;
 
-if (d_cur_tgt_pos isEqualTo [] || d_preemptive_special_event) exitWith {true};
+if (d_cur_tgt_pos isEqualTo [] || d_preemptive_special_event || d_paradrop_no_restrictions == 1) exitWith {true};
 
 private _res = (_this # 0) distance2D d_cur_tgt_pos > d_cur_target_radius + 200;
 

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -1283,7 +1283,7 @@ class Params {
 	
 	class d_civ_type {
 		title = "$STR_DOM_MISSIONSTRING_CIVILIAN_TYPE";
-		values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12};
+		values[] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13};
 		default = 0;
 		texts[] = {"$STR_DOM_MISSIONSTRING_418DEFAULT",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_AFRICAN",
@@ -1292,19 +1292,21 @@ class Params {
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_TANOAN",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CUP_CHERNARUS",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_CHERNARUS_WINTER",
+			// CFP civilians - static civs work but dynamic civs are broken (civilian presence module)
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFGHANISTAN",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFRICAN_CHRISTIAN",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFRICAN_ISLAMIC",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_ASIAN",
 			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_MALDEN",
-			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_MIDDLE_EAST"};
+			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_MIDDLE_EAST",
+			"$STR_DOM_MISSIONSTRING_CIV_TYPE_CUP_TAKISTAN"};
 	};
 
 	class d_civ_unitcount {
 		title = "$STR_DOM_MISSIONSTRING_1893";
-		values[] = {10,15,20,25,30,40,50,75,100};
-		default = 10;
-		texts[] = {"10","15","20","25","30","40","50","75","100"};
+		values[] = {0,10,15,20,25,30,40,50,75,100};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1063","10","15","20","25","30","40","50","75","100"};
 	};
 
 	class d_civ_groupcount {
@@ -1727,6 +1729,20 @@ class Params {
 		values[] = {500, 700, 888, 1000, 2000, 5000};
 		default = 2000;
 		texts[] = {"500 m","700 m","888 m","1000 m","2000 m","5000 m"};
+	};
+	
+	class d_force_steerable_parachutes {
+		title = "$STR_DOM_MISSIONSTRING_FORCE_STEERABLE_PARACHUTES";
+		values[] = {0,1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+	};
+	
+	class d_paradrop_no_restrictions {
+		title = "$STR_DOM_MISSIONSTRING_PARACHUTES_UNRESTRICTED";
+		values[] = {0,1};
+		default = 0;
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
 	};
 
 	class d_params_dl_14 {

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -2841,15 +2841,30 @@ d_sabotage_E = [["O_SFIA_exp_lxWS"]];
 	];
 
 	d_cupCivsTakistan = [
-		"CUP_C_TK_Man_05_Waist", 1,
-		"CUP_C_TK_Man_06_Waist", 1,
-		"CUP_C_TK_Man_01_Coat", 1,
+		"CUP_C_TK_Man_04", 1,
+		"CUP_C_TK_Man_04_Jack", 1,
+		"CUP_C_TK_Man_04_Waist", 1,
+		"CUP_C_TK_Man_07", 1,
+		"CUP_C_TK_Man_07_Coat", 1,
+		"CUP_C_TK_Man_07_Waist", 1,
+		"CUP_C_TK_Man_08", 1,
+		"CUP_C_TK_Man_08_Coat", 1,
 		"CUP_C_TK_Man_08_Waist", 1,
-		"CUP_C_TK_Man_03_Coat", 1,
-		"CUP_C_TK_Man_01_Jack", 1,
+		"CUP_C_TK_Man_05_Coat", 1,
+		"CUP_C_TK_Man_05_Jack", 1,
+		"CUP_C_TK_Man_05_Waist", 1,
+		"CUP_C_TK_Man_06_Coat", 1,
 		"CUP_C_TK_Man_06_Jack", 1,
+		"CUP_C_TK_Man_06_Waist", 1,
+		"CUP_C_TK_Man_02", 1,
+		"CUP_C_TK_Man_02_Jack", 1,
+		"CUP_C_TK_Man_02_Waist", 1,
+		"CUP_C_TK_Man_01_Coat", 1,
+		"CUP_C_TK_Man_01_Jack", 1,
+		"CUP_C_TK_Man_01_Waist", 1,
+		"CUP_C_TK_Man_03_Coat", 1,
 		"CUP_C_TK_Man_03_Jack", 1,
-		"CUP_C_TK_Man_03_Jack", 1
+		"CUP_C_TK_Man_03_Waist", 1
 	];
 	
 	private _civsLivonia = [

--- a/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
@@ -98,8 +98,8 @@ sleep 7;
 
 private _newgroups_inf = [];
 private _newgroups_veh = [];
-// calculate the sum of all groups of AI configured for the maintarget and size the enemy force accordingly (half + 3)
-private _targetGroupCount = round ((d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt) / 2) + 3;
+// calculate the sum of all groups of AI configured for the maintarget and size the enemy force accordingly
+private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
 private _enemyForceInf = [];
 
 for "_i" from 0 to _targetGroupCount do {
@@ -110,27 +110,23 @@ private _incoming_vehs = [];
 
 if (d_WithLessArmor == 0 || d_WithLessArmor == 3) then {
 	// "normal" or random which we force to normal
-	_incoming_vehs = ["jeep_mg", "wheeled_apc", "tracked_apc", "tank"];
+	_incoming_vehs = ["jeep_mg", "wheeled_apc"];
 };
 
 if (d_WithLessArmor == 1) then {
 	// "less"
-	_incoming_vehs = ["jeep_mg", "wheeled_apc"];
+	_incoming_vehs = ["jeep_mg", "jeep_mg"];
 };
 
 if (d_WithLessArmor == 4) then {
 	// high
-	_incoming_vehs = ["jeep_mg", "wheeled_apc", "wheeled_apc", "tracked_apc", "tank", "tank"]
+	_incoming_vehs = ["jeep_mg", "wheeled_apc", "tracked_apc"];
 };
 
 {
 	private _unitlist = [_x, d_enemy_side_short] call d_fnc_getunitlistm;
 	private _newgroup = [d_side_enemy] call d_fnc_creategroup;
-	private _rand_pos = [[[_spawn_pos, 30]],["water"]] call BIS_fnc_randomPos;
-	if (50 > random 100) then {
-		// spread units out
-		_rand_pos = [[[_spawn_pos, 65]],[[_spawn_pos, 30], "water"]] call BIS_fnc_randomPos;
-	};
+	private _rand_pos = [[[_spawn_pos, 175]],[]] call BIS_fnc_randomPos;
 	private _units = [_rand_pos, _unitlist, _newgroup, false, true] call d_fnc_makemgroup;
 	{
 		_x setSkill ["courage", 1];
@@ -183,7 +179,18 @@ sleep 30;
 // infantry go first
 {
 	// each group moves toward a random position near the target center
-	_wp_pos = [[[_target_center, (d_cur_target_radius * 0.2)]],["water"]] call BIS_fnc_randomPos;
+	private _wp_pos = [];
+	if (33 > random 100) then {
+		// some enemy groups stay back from target center, near midpoint of enemy start and target center
+		private _midpoint_pos = [
+			((_target_center # 0) + (_spawn_pos # 0))/2,
+			((_target_center # 1) + (_spawn_pos # 1))/2
+		];
+		_wp_pos = [[[_midpoint_pos, (d_cur_target_radius * 0.2)]],["water"]] call BIS_fnc_randomPos;
+	} else {
+		// near target center
+		_wp_pos = [[[_target_center, (d_cur_target_radius * 0.2)]],["water"]] call BIS_fnc_randomPos;
+	};
 	//if (25 > random 100) then {
 	if (false) then { // todo - fix non-teleport occupyhouse, skipping for now, many units are not moving at all
 		// some units will garrison in a building near the random position (walk to the position, not teleported)

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
@@ -37,10 +37,12 @@ d_kb_logic1 kbTell [
 private _newgroups_inf = [];
 
 // calculate the sum of all groups of AI already in the maintarget
-private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt;
+private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
+// guerrillas should be outnumbered
+_guerrillaGroupCount = round(_targetGroupCount / 3) max 1;
 private _guerrillaForce = [];
 // size the guerrilla force
-for "_i" from 0 to (round(_targetGroupCount / 4) + 1) do {
+for "_i" from 0 to _guerrillaGroupCount do {
 	_guerrillaForce pushBack "allmen";
 };
 
@@ -54,7 +56,7 @@ private _guerrillaBaseSkill = 0.85;
 	};
 	private _newgroup = [independent] call d_fnc_creategroup;
 	// random position within 125m of target center
-	private _rand_pos = [[[_target_center, 40]],["water"]] call BIS_fnc_randomPos;
+	private _rand_pos = [[[_target_center, 80]],["water"]] call BIS_fnc_randomPos;
 	private _units = [_rand_pos, _unitlist, _newgroup, false, true, 5, true] call d_fnc_makemgroup;
 	{
 		_x setSkill _guerrillaBaseSkill;
@@ -66,8 +68,8 @@ private _guerrillaBaseSkill = 0.85;
 	if (d_with_dynsim == 0) then {
 		[_newgroup, 0] spawn d_fnc_enabledynsim;
 	};
-	if (random 100 > 66) then {
-		// garrison 2/3rds of the units
+	if (random 100 > 50) then {
+		// garrison 1/2 of the units
 		private _unitsNotGarrisoned = [
 			_rand_pos,
 			_units,

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -94,23 +94,27 @@ if (_with_vehicles) then {
 	private _incoming_vehs = [];
 	if (d_WithLessArmor == 0 || d_WithLessArmor == 3) then {
     	// "normal" or random which we force to normal
-    	_incoming_vehs = ["jeep_mg", "wheeled_apc", "tracked_apc"];
+    	_incoming_vehs = ["jeep_mg", "wheeled_apc"];
     };
     
     if (d_WithLessArmor == 1) then {
     	// "less"
-    	_incoming_vehs = ["jeep_mg", "wheeled_apc"];
+    	_incoming_vehs = ["jeep_mg", "jeep_mg"];
     };
     
     if (d_WithLessArmor == 4) then {
     	// high
-    	_incoming_vehs = ["jeep_mg", "wheeled_apc", "tracked_apc", "tracked_apc"];
+    	_incoming_vehs = ["jeep_mg", "wheeled_apc", "tracked_apc"];
+    };
+    // preemptive overrides
+    if (d_preemptive_special_event) then {
+    	_incoming_vehs = ["jeep_mg", "tracked_apc"];
     };
 	private _vdir = _spawn_pos getDir _target_center;
     {
     	private _unitlist = [_x, "G"] call d_fnc_getunitlistv;
     	private _newgroup = [independent] call d_fnc_creategroup;
-    	private _rand_pos = [[[_spawn_pos, 30]],["water"]] call BIS_fnc_randomPos;
+    	private _rand_pos = [[[_spawn_pos, 150]],[]] call BIS_fnc_randomPos;
 		private _road_list = _rand_pos nearroads 30;
 		private _spawn_pos_foreach = [];
 		if (!(_road_list isEqualTo [])) then {
@@ -133,17 +137,13 @@ if (_with_vehicles) then {
 };
 
 // calculate the sum of all groups of AI already in the maintarget and size the guerrilla force accordingly
-private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt;
+private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
 
 // guerrillas should be outnumbered
-_guerrillaGroupCount = round(_targetGroupCount / 5) max 1;
+_guerrillaGroupCount = round(_targetGroupCount / 3) max 1;
 _guerrillaForce = [];
 for "_i" from 0 to _guerrillaGroupCount do {
 	_guerrillaForce pushBack "allmen";
-};
-
-if (d_preemptive_special_event) then {
-	_incoming_vehs = ["jeep_mg", "tracked_apc"];
 };
 
 private _guerrillaBaseSkill = 0.85;
@@ -155,7 +155,7 @@ private _guerrillaBaseSkill = 0.85;
 		_unitlist = ["Indep","IND_F","Infantry","HAF_InfTeam_AT"] call d_fnc_GetConfigGroup;
 	};
 	private _newgroup = [independent] call d_fnc_creategroup;
-	private _rand_pos = [[[_spawn_pos, 35]],["water"]] call BIS_fnc_randomPos;
+	private _rand_pos = [[[_spawn_pos, 100]],["water"]] call BIS_fnc_randomPos;
 	private _units = [_rand_pos, _unitlist, _newgroup, false, true, 5, true] call d_fnc_makemgroup;
 	{
 		_x setSkill _guerrillaBaseSkill;

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -63,6 +63,9 @@ if (d_civ_type > 0) then {
 	if (d_civ_type == 12) then {
 		d_civArray_current =+ d_civ_faction_cfp_middle_east;
 	};
+	if (d_civ_type == 13) then {
+		d_civArray_current =+ d_cupCivsTakistan;
+	};
 	// TODO - IFA civs
 } else {
 	d_civArray_current =+ d_civArray;
@@ -301,7 +304,7 @@ while {_tries_remaining > 0 && {count d_cur_tgt_civ_modules_presencesafespot < 5
 
 };
 
-if (count d_cur_tgt_civ_modules_presencesafespot > 0) then {
+if (count d_cur_tgt_civ_modules_presencesafespot > 0 && { d_civ_unitcount > 0}) then {
 	// we found at least one civilian location so we can create and configure the module PresenceUnit and Presence
 	private _mu1_pos = position (selectRandom d_cur_tgt_civ_modules_presencesafespot);
 	private _mu1 = _grp_civmodule createUnit ["ModuleCivilianPresenceUnit_F", _mu1_pos, [], 0, "NONE"];

--- a/co30_Domination.Altis/server/fn_createdrop.sqf
+++ b/co30_Domination.Altis/server/fn_createdrop.sqf
@@ -82,7 +82,7 @@ _wp setWaypointForceBehaviour true;
 private _vecdist = _chopper distance2D _drop_pos;
 
 //_chopper flyInHeight 100;
-#define __dist_to_drop 150
+#define __dist_to_drop 300
 private _may_exit = false;
 sleep 12 + random 12;
 if (!isNil "_player" && {!isNull _player}) then {

--- a/co30_Domination.Altis/stringtable.xml
+++ b/co30_Domination.Altis/stringtable.xml
@@ -6915,6 +6915,30 @@
 <Chinese>沒有跳傘旗幟:</Chinese>
 <French>Pas de parachutage du drapeau:</French>
 </Key>
+<Key ID="STR_DOM_MISSIONSTRING_FORCE_STEERABLE_PARACHUTES">
+<English>Force steerable parachutes:</English>
+<Spanish>Force steerable parachutes:</Spanish>
+<Portuguese>Force steerable parachutes:</Portuguese>
+<Korean>Force steerable parachutes:</Korean>
+<Japanese>Force steerable parachutes:</Japanese>
+<Original>Force steerable parachutes:</Original>
+<Russian>Force steerable parachutes:</Russian>
+<Chinesesimp>Force steerable parachutes:</Chinesesimp>
+<Chinese>Force steerable parachutes:</Chinese>
+<French>Force steerable parachutes:</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_PARACHUTES_UNRESTRICTED">
+<English>Players may parajump to any location:</English>
+<Spanish>Players may parajump to any location:</Spanish>
+<Portuguese>Players may parajump to any location:</Portuguese>
+<Korean>Players may parajump to any location:</Korean>
+<Japanese>Players may parajump to any location:</Japanese>
+<Original>Players may parajump to any location:</Original>
+<Russian>Players may parajump to any location:</Russian>
+<Chinesesimp>Players may parajump to any location:</Chinesesimp>
+<Chinese>Players may parajump to any location:</Chinese>
+<French>Players may parajump to any location:</French>
+</Key>
 <Key ID="STR_DOM_MISSIONSTRING_1098">
 <English>Parachute from base:</English>
 <Spanish>Salto en paracaídas desde base:</Spanish>
@@ -12525,88 +12549,100 @@
 <French>Chernarus civilians (CUP)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_CHERNARUS_WINTER">
-<English>Chernarus winter civilians (CFP)</English>
-<Spanish>Chernarus winter civilians (CFP)</Spanish>
-<Portuguese>Chernarus winter civilians (CFP)</Portuguese>
-<Korean>Chernarus winter civilians (CFP)</Korean>
-<Japanese>Chernarus winter civilians (CFP)</Japanese>
-<Original>Chernarus winter civilians (CFP)</Original>
-<Russian>Chernarus winter civilians (CFP)</Russian>
-<Chinesesimp>Chernarus winter civilians (CFP)</Chinesesimp>
-<Chinese>Chernarus winter civilians (CFP)</Chinese>
-<French>Chernarus winter civilians (CFP)</French>
+<English>Chernarus winter civilians (CFP) (static only)</English>
+<Spanish>Chernarus winter civilians (CFP) (static only)</Spanish>
+<Portuguese>Chernarus winter civilians (CFP) (static only)</Portuguese>
+<Korean>Chernarus winter civilians (CFP) (static only)</Korean>
+<Japanese>Chernarus winter civilians (CFP) (static only)</Japanese>
+<Original>Chernarus winter civilians (CFP) (static only)</Original>
+<Russian>Chernarus winter civilians (CFP) (static only)</Russian>
+<Chinesesimp>Chernarus winter civilians (CFP) (static only)</Chinesesimp>
+<Chinese>Chernarus winter civilians (CFP) (static only)</Chinese>
+<French>Chernarus winter civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFGHANISTAN">
-<English>Afghanistan civilians (CFP)</English>
-<Spanish>Afghanistan civilians (CFP)</Spanish>
-<Portuguese>Afghanistan civilians (CFP)</Portuguese>
-<Korean>Afghanistan civilians (CFP)</Korean>
-<Japanese>Afghanistan civilians (CFP)</Japanese>
-<Original>Afghanistan civilians (CFP)</Original>
-<Russian>Afghanistan civilians (CFP)</Russian>
-<Chinesesimp>Afghanistan civilians (CFP)</Chinesesimp>
-<Chinese>Afghanistan civilians (CFP)</Chinese>
-<French>Afghanistan civilians (CFP)</French>
+<English>Afghanistan civilians (CFP) (static only)</English>
+<Spanish>Afghanistan civilians (CFP) (static only)</Spanish>
+<Portuguese>Afghanistan civilians (CFP) (static only)</Portuguese>
+<Korean>Afghanistan civilians (CFP) (static only)</Korean>
+<Japanese>Afghanistan civilians (CFP) (static only)</Japanese>
+<Original>Afghanistan civilians (CFP) (static only)</Original>
+<Russian>Afghanistan civilians (CFP) (static only)</Russian>
+<Chinesesimp>Afghanistan civilians (CFP) (static only)</Chinesesimp>
+<Chinese>Afghanistan civilians (CFP) (static only)</Chinese>
+<French>Afghanistan civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFRICAN_CHRISTIAN">
-<English>African (Christian) civilians (CFP)</English>
-<Spanish>African (Christian) civilians (CFP)</Spanish>
-<Portuguese>African (Christian) civilians (CFP)</Portuguese>
-<Korean>African (Christian) civilians (CFP)</Korean>
-<Japanese>African (Christian) civilians (CFP)</Japanese>
-<Original>African (Christian) civilians (CFP)</Original>
-<Russian>African (Christian) civilians (CFP)</Russian>
-<Chinesesimp>African (Christian) civilians (CFP)</Chinesesimp>
-<Chinese>African (Christian) civilians (CFP)</Chinese>
-<French>African (Christian) civilians (CFP)</French>
+<English>African (Christian) civilians (CFP) (static only)</English>
+<Spanish>African (Christian) civilians (CFP) (static only)</Spanish>
+<Portuguese>African (Christian) civilians (CFP) (static only)</Portuguese>
+<Korean>African (Christian) civilians (CFP) (static only)</Korean>
+<Japanese>African (Christian) civilians (CFP) (static only)</Japanese>
+<Original>African (Christian) civilians (CFP) (static only)</Original>
+<Russian>African (Christian) civilians (CFP) (static only)</Russian>
+<Chinesesimp>African (Christian) civilians (CFP) (static only)</Chinesesimp>
+<Chinese>African (Christian) civilians (CFP) (static only)</Chinese>
+<French>African (Christian) civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_AFRICAN_ISLAMIC">
-<English>African (Islamic) civilians (CFP)</English>
-<Spanish>African (Islamic) civilians (CFP)</Spanish>
-<Portuguese>African (Islamic) civilians (CFP)</Portuguese>
-<Korean>African (Islamic) civilians (CFP)</Korean>
-<Japanese>African (Islamic) civilians (CFP)</Japanese>
-<Original>African (Islamic) civilians (CFP)</Original>
-<Russian>African (Islamic) civilians (CFP)</Russian>
-<Chinesesimp>African (Islamic) civilians (CFP)</Chinesesimp>
-<Chinese>African (Islamic) civilians (CFP)</Chinese>
-<French>African (Islamic) civilians (CFP)</French>
+<English>African (Islamic) civilians (CFP) (static only)</English>
+<Spanish>African (Islamic) civilians (CFP) (static only)</Spanish>
+<Portuguese>African (Islamic) civilians (CFP) (static only)</Portuguese>
+<Korean>African (Islamic) civilians (CFP) (static only)</Korean>
+<Japanese>African (Islamic) civilians (CFP) (static only)</Japanese>
+<Original>African (Islamic) civilians (CFP) (static only)</Original>
+<Russian>African (Islamic) civilians (CFP) (static only)</Russian>
+<Chinesesimp>African (Islamic) civilians (CFP) (static only)</Chinesesimp>
+<Chinese>African (Islamic) civilians (CFP) (static only)</Chinese>
+<French>African (Islamic) civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_ASIAN">
-<English>Asian civilians (CFP)</English>
-<Spanish>Asian civilians (CFP)</Spanish>
-<Portuguese>Asian civilians (CFP)</Portuguese>
-<Korean>Asian civilians (CFP)</Korean>
-<Japanese>Asian civilians (CFP)</Japanese>
-<Original>Asian civilians (CFP)</Original>
-<Russian>Asian civilians (CFP)</Russian>
-<Chinesesimp>Asian civilians (CFP)</Chinesesimp>
-<Chinese>Asian civilians (CFP)</Chinese>
-<French>Asian civilians (CFP)</French>
+<English>Asian civilians (CFP) (static only)</English>
+<Spanish>Asian civilians (CFP) (static only)</Spanish>
+<Portuguese>Asian civilians (CFP) (static only)</Portuguese>
+<Korean>Asian civilians (CFP) (static only)</Korean>
+<Japanese>Asian civilians (CFP) (static only)</Japanese>
+<Original>Asian civilians (CFP) (static only)</Original>
+<Russian>Asian civilians (CFP) (static only)</Russian>
+<Chinesesimp>Asian civilians (CFP) (static only)</Chinesesimp>
+<Chinese>Asian civilians (CFP) (static only)</Chinese>
+<French>Asian civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_MALDEN">
-<English>Malden civilians (CFP)</English>
-<Spanish>Malden civilians (CFP)</Spanish>
-<Portuguese>Malden civilians (CFP)</Portuguese>
-<Korean>Malden civilians (CFP)</Korean>
-<Japanese>Malden civilians (CFP)</Japanese>
-<Original>Malden civilians (CFP)</Original>
-<Russian>Malden civilians (CFP)</Russian>
-<Chinesesimp>Malden civilians (CFP)</Chinesesimp>
-<Chinese>Malden civilians (CFP)</Chinese>
-<French>Malden civilians (CFP)</French>
+<English>Malden civilians (CFP) (static only)</English>
+<Spanish>Malden civilians (CFP) (static only)</Spanish>
+<Portuguese>Malden civilians (CFP) (static only)</Portuguese>
+<Korean>Malden civilians (CFP) (static only)</Korean>
+<Japanese>Malden civilians (CFP) (static only)</Japanese>
+<Original>Malden civilians (CFP) (static only)</Original>
+<Russian>Malden civilians (CFP) (static only)</Russian>
+<Chinesesimp>Malden civilians (CFP) (static only)</Chinesesimp>
+<Chinese>Malden civilians (CFP) (static only)</Chinese>
+<French>Malden civilians (CFP) (static only)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CFP_MIDDLE_EAST">
-<English>Middle East civilians (CFP)</English>
-<Spanish>Middle East civilians (CFP)</Spanish>
-<Portuguese>Middle East civilians (CFP)</Portuguese>
-<Korean>Middle East civilians (CFP)</Korean>
-<Japanese>Middle East civilians (CFP)</Japanese>
-<Original>Middle East civilians (CFP)</Original>
-<Russian>Middle East civilians (CFP)</Russian>
-<Chinesesimp>Middle East civilians (CFP)</Chinesesimp>
-<Chinese>Middle East civilians (CFP)</Chinese>
-<French>Middle East civilians (CFP)</French>
+<English>Middle East civilians (CFP) (static only)</English>
+<Spanish>Middle East civilians (CFP) (static only)</Spanish>
+<Portuguese>Middle East civilians (CFP) (static only)</Portuguese>
+<Korean>Middle East civilians (CFP) (static only)</Korean>
+<Japanese>Middle East civilians (CFP) (static only)</Japanese>
+<Original>Middle East civilians (CFP) (static only)</Original>
+<Russian>Middle East civilians (CFP) (static only)</Russian>
+<Chinesesimp>Middle East civilians (CFP) (static only)</Chinesesimp>
+<Chinese>Middle East civilians (CFP) (static only)</Chinese>
+<French>Middle East civilians (CFP) (static only)</French>
+</Key>
+<Key ID="STR_DOM_MISSIONSTRING_CIV_TYPE_CUP_TAKISTAN">
+<English>Takistan civilians (CUP)</English>
+<Spanish>Takistan civilians (CUP)</Spanish>
+<Portuguese>Takistan civilians (CUP)</Portuguese>
+<Korean>Takistan civilians (CUP)</Korean>
+<Japanese>Takistan civilians (CUP)</Japanese>
+<Original>Takistan civilians (CUP)</Original>
+<Russian>Takistan civilians (CUP)</Russian>
+<Chinesesimp>Takistan civilians (CUP)</Chinesesimp>
+<Chinese>Takistan civilians (CUP)</Chinese>
+<French>Takistan civilians (CUP)</French>
 </Key>
 <Key ID="STR_DOM_MISSIONSTRING_1893">
 <English>Civilians - civilian unit count (walking)</English>


### PR DESCRIPTION
added: CUP Takistan civilians
fixed: walking civilians may be disabled
added: server parameter for steerable parachutes regardless of scenario (ie-- IFA, SOG)
added: server parameter for no restrictions to player parajump location (ie-- the maintarget area)
fixed: combat UAV spawned at correct altitude
added: more no-HUD
