### PR TITLE
civs move to start position

### DIFF
--- a/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_enemy_incoming.sqf
@@ -99,7 +99,7 @@ sleep 7;
 private _newgroups_inf = [];
 private _newgroups_veh = [];
 // calculate the sum of all groups of AI configured for the maintarget and size the enemy force accordingly
-private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
+private _targetGroupCount = d_occ_cnt_current + d_ovrw_cnt_current + d_amb_cnt_current + d_snp_cnt + d_grp_cnt_footpatrol;
 private _enemyForceInf = [];
 
 for "_i" from 0 to _targetGroupCount do {

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
@@ -37,7 +37,7 @@ d_kb_logic1 kbTell [
 private _newgroups_inf = [];
 
 // calculate the sum of all groups of AI already in the maintarget
-private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
+private _targetGroupCount = d_occ_cnt_current + d_ovrw_cnt_current + d_amb_cnt_current + d_snp_cnt + d_grp_cnt_footpatrol;
 // guerrillas should be outnumbered
 _guerrillaGroupCount = round(_targetGroupCount / 3) max 1;
 private _guerrillaForce = [];

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
@@ -47,7 +47,7 @@ for "_i" from 0 to _guerrillaGroupCount do {
 };
 
 private _guerrillaBaseSkill = 0.85;
-
+private _markerpos = [];
 {
 	private _unitlist = [_x, "G"] call d_fnc_getunitlistm;
 	if !(d_faction_independent_array isEqualTo []) then {
@@ -56,6 +56,9 @@ private _guerrillaBaseSkill = 0.85;
 	private _newgroup = [independent] call d_fnc_creategroup;
 	// random position within 125m of target center
 	private _rand_pos = [[[_target_center, 80]],["water"]] call BIS_fnc_randomPos;
+	if (_markerpos isEqualTo []) then {
+		_markerpos = _rand_pos;
+	};
 	private _units = [_rand_pos, _unitlist, _newgroup, false, true, 5, true] call d_fnc_makemgroup;
 	{
 		_x setSkill _guerrillaBaseSkill;
@@ -88,6 +91,9 @@ private _guerrillaBaseSkill = 0.85;
 		
 } forEach _guerrillaForce;
 
+_marker = ["d_mt_event_marker_guerrillainfantry_defend", _markerpos, "ICON","ColorBlack", [1, 1], localize "STR_DOM_MISSIONSTRING_GUERRILLAS", 0, "mil_start"] call d_fnc_CreateMarkerGlobal;
+[_marker, "STR_DOM_MISSIONSTRING_GUERRILLAS"] remoteExecCall ["d_fnc_setmatxtloc", [0, -2] select isDedicated];
+
 private _all_dead = false;
 while {sleep 1; !d_mt_done && {!_all_dead}} do {
 	_foundAlive = _newgroups_inf findIf {(units _x) findIf {alive _x} > -1} > -1;
@@ -101,3 +107,4 @@ publicVariable "d_mt_event_messages_array";
 diag_log [format ["cleanup of event: %1", _mt_event_key]];
 diag_log [format ["cleanup of event array: %1", _x_mt_event_ar]];
 _x_mt_event_ar call d_fnc_deletearrayunitsvehicles;
+deleteMarker _marker;

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -137,7 +137,7 @@ if (_with_vehicles) then {
 };
 
 // calculate the sum of all groups of AI already in the maintarget and size the guerrilla force accordingly
-private _targetGroupCount = d_occ_cnt + d_ovrw_cnt + d_amb_cnt + d_snp_cnt + d_grp_cnt_footpatrol;
+private _targetGroupCount = d_occ_cnt_current + d_ovrw_cnt_current + d_amb_cnt_current + d_snp_cnt + d_grp_cnt_footpatrol;
 
 // guerrillas should be outnumbered
 _guerrillaGroupCount = round(_targetGroupCount / 3) max 1;

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -494,6 +494,9 @@ __TRACE("start of forEach _buildingPosArray")
 										//	d_cur_tgt_civ_units deleteAt (d_cur_tgt_civ_units find (_units select _unitIndex));
 										//	deleteVehicle (_units select _unitIndex);
 										//};
+										if (side _uuidx == civilian) then {
+											_uuidx setVariable ["civ_startpos", getPos _uuidx];
+										};
 									};//end if _isDryRun
 									I(_unitIndex)
 									if (_fillEvenly) then {
@@ -513,7 +516,7 @@ __TRACE("start of forEach _buildingPosArray")
 			};//end for
 			//diag_log ["could not find a suitable angle, skipping this position"];
 		} else {
-			diag_log [format ["position was skipped and %1 positions remain", count _posArray]];
+			//diag_log [format ["position was skipped and %1 positions remain", count _posArray]];
 		};//end if (_skip_position)
 	};//end while
 } forEach _buildingPosArray;
@@ -521,7 +524,7 @@ __TRACE("start of forEach _buildingPosArray")
 __TRACE("end of forEach _buildingPosArray")
 
 if (_unitIndex < count _units && {!isNil "_theBuilding"}) then {
-	diag_log [format ["only %1 units out of %2 total units were moved", _unitIndex, count _units]];
+	//diag_log [format ["only %1 units out of %2 total units were moved", _unitIndex, count _units]];
 	for [{_k = _unitIndex}, {(_k < count _units)}, {I(_k)}] do {
 		private _unit = _units select _k;
 		private _attempts = 0;
@@ -549,11 +552,14 @@ if (_unitIndex < count _units && {!isNil "_theBuilding"}) then {
 				deleteGroup _civgrptemp;
 				//diag_log [format ["placing a unit in a non-standard position, raw fuzzy position: %1 and unit fuzzy position: %2", _targetPosFuzzy, _targetPosFuzzyUnit]];
 				_unit setVehiclePosition [[_targetPosFuzzyUnit # 0, _targetPosFuzzyUnit # 1], [], 1.7, "NONE"];
+				if (side _unit == civilian) then {
+					_unit setVariable ["civ_startpos", getPos _unit];
+				};
 				_foundgood = true;
 			};
 		};
 		if (isNil "_civtemp" || {!_foundgood || {getPos _civtemp # 0 < 100 || {getPos _civtemp # 1 < 100 || {side _unit == civilian && {!((_unit) call d_fnc_isinhouse)}}}}}) then {
-			diag_log ["still a bad position after 99 attempts, giving up and removing the unit"];
+			//diag_log ["still a bad position after 99 attempts, giving up and removing the unit"];
 			if (side _unit == civilian) then {
 				d_cur_tgt_civ_units deleteAt (d_cur_tgt_civ_units find _unit);
 			};

--- a/co30_Domination.Altis/scripts/fn_afterfirednear_civ_global.sqf
+++ b/co30_Domination.Altis/scripts/fn_afterfirednear_civ_global.sqf
@@ -11,6 +11,7 @@ if ((damage _unit) > 0.05) then {
 private _last_threatened_ts = (agent teamMember _unit) getVariable ["civ_last_firednear_or_threatened", 0];
 private _last_dangerclose_ts = (agent teamMember _unit) getVariable ["civ_last_dangerclose", 0];
 private _civ_is_walking = (agent teamMember _unit) getVariable ["civ_is_walking", false];
+private _civ_startpos = (agent teamMember _unit) getVariable ["civ_startpos", []];
 {
 	// if weapon is raised close by then immediately lay down and set threatend timestamp
 	if !(weaponLowered _x) exitWith {
@@ -35,7 +36,7 @@ private _civ_is_walking = (agent teamMember _unit) getVariable ["civ_is_walking"
 } forEach (allPlayers select { _x distance2D _unit < 6 });
 private _elapsed_time_since_threatened = (time - _last_threatened_ts);
 private _elapsed_time_since_dangerclose = (time - _last_dangerclose_ts);
-if (_elapsed_time_since_dangerclose > 7 && {!_civ_is_walking}) then {
+if (_elapsed_time_since_dangerclose > 7 && {!(_civ_startpos isEqualTo []) && {(_unit distance2D _civ_startpos) < 2 && {!_civ_is_walking}}}) then {
 	// static civilian was allowed to move for a few seconds but must stop moving now 
 	_unit forceSpeed 0;
 };
@@ -47,4 +48,9 @@ if (_elapsed_time_since_threatened > 30 && {_elapsed_time_since_threatened <= 45
 };
 if (_elapsed_time_since_threatened > 45) then {
 	_unit setUnitPos "AUTO";
+	if (!(_civ_startpos isEqualTo []) && {(_unit distance2D _civ_startpos) > 2}) then {
+		// static civilian moved away from startpos, now should move back
+		_unit forceSpeed -1;
+		_unit moveTo _civ_startpos;
+	};
 };

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -117,7 +117,7 @@ private _placeCivilianCluster = {
 	_unit_count = 6 max floor(random 12);
 	if (count _posArray > 5 && {1 > random 10}) then {
 		// small chance for larger buildings (more than 5 positions) to have many civs
-		diag_log ["randomly chose to spawn a large civilian group"];
+		//diag_log ["randomly chose to spawn a large civilian group"];
 		_unit_count = 11 max floor(random 17);
 	};
 	private _units_civ_cluster = [];
@@ -209,15 +209,17 @@ private _placeCivilianCluster = {
 	} forEach d_cur_tgt_civ_modules_presencesafespot;
 #endif
 	
+	private _debug_count = count _units_civ_cluster;
 	{
 		if (getPos _x # 0 < 75 && getPos _x # 1 < 75) then {
-			diag_log ["found a civilian unit placed near [0,0,0] unit will be deleted now."];
+			//diag_log ["found a civilian unit placed near [0,0,0] unit will be deleted now."];
 			d_cur_tgt_civ_units deleteAt (d_cur_tgt_civ_units find _x);
 			deleteVehicle _x;
+			_debug_count = _debug_count - 1;
 		};
 	} forEach _units_civ_cluster;
 	
-	diag_log [format ["civilian cluster successfully created %1 civ units", count _units_civ_cluster]];
+	diag_log [format ["civilian cluster successfully created %1 civ units", _debug_count]];
 };
 
 #ifdef __DEBUG__

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -43,6 +43,92 @@ __TRACE_1("","_trg_center")
 __TRACE_3("","_trgobj","_radius","_patrol_radius")
 __TRACE_1("","_this")
 
+// assign or calculate the number of enemy groups for overwatch, ambush and occupy infantry
+// occupy group count
+d_occ_cnt_current = 0;
+if (d_occ_cnt == -1 || d_occ_cnt == -2 || d_occ_cnt == -3 || d_occ_cnt == -4 || d_occ_cnt == -5) then {
+	//adaptive group count
+	//calculate number of occupy groups by counting the number of building in the maintarget area * spawn factor
+	private _occ_spawn_factor = 0;
+	if (d_occ_cnt == -1) then {
+		_occ_spawn_factor = 0.03;  // adaptive (low)
+	};
+	if (d_occ_cnt == -2) then {
+		_occ_spawn_factor = 0.06;  // adaptive (normal)
+	};
+	if (d_occ_cnt == -3) then {
+		_occ_spawn_factor = 0.12;  // adaptive (high)
+	};
+	if (d_occ_cnt == -4) then {
+		_occ_spawn_factor = 0.20;  // adaptive (very high)
+	};
+	if (d_occ_cnt == -5) then {
+		_occ_spawn_factor = 0.75;  // adaptive (extreme)
+	};
+	private _bldg_count = count ([_trg_center, d_occ_rad] call d_fnc_getbldgswithpositions);
+	private _occ_cnt_max = floor(_occ_spawn_factor * 100);
+	d_occ_cnt_current = floor (_bldg_count * _occ_spawn_factor) min _occ_cnt_max;
+	diag_log [format ["_occ_cnt adaptive value: %1", d_occ_cnt_current]];
+} else {
+	d_occ_cnt_current = d_occ_cnt;
+};
+// overwatch group count
+d_ovrw_cnt_current = 0;
+if (d_ovrw_cnt == -1 || d_ovrw_cnt == -2 || d_ovrw_cnt == -3 || d_ovrw_cnt == -4 || d_ovrw_cnt == -5) then {
+	//adaptive group count
+	//calculate number of overwatch groups by counting the number of building in the maintarget area * spawn factor
+	private _ovrw_spawn_factor = 0;
+	if (d_ovrw_cnt == -1) then {
+		_ovrw_spawn_factor = 0.03;  // adaptive (low)
+	};
+	if (d_ovrw_cnt == -2) then {
+		_ovrw_spawn_factor = 0.06;  // adaptive (normal)
+	};
+	if (d_ovrw_cnt == -3) then {
+		_ovrw_spawn_factor = 0.12;  // adaptive (high)
+	};
+	if (d_ovrw_cnt == -4) then {
+		_ovrw_spawn_factor = 0.20;  // adaptive (very high)
+	};
+	if (d_ovrw_cnt == -5) then {
+		_ovrw_spawn_factor = 0.75;  // adaptive (extreme)
+	};
+	private _bldg_count = count ([_trg_center, d_ovrw_rad] call d_fnc_getbldgswithpositions);
+	private _ovrw_cnt_max = floor(_ovrw_spawn_factor * 100);
+	d_ovrw_cnt_current = floor (_bldg_count * _ovrw_spawn_factor) min _ovrw_cnt_max;
+	diag_log [format ["_ovrw_cnt adaptive value: %1", d_ovrw_cnt_current]];
+} else {
+	d_ovrw_cnt_current = d_ovrw_cnt;
+};
+// ambush group count
+d_amb_cnt_current = 0;
+if (d_amb_cnt == -1 || d_amb_cnt == -2 || d_amb_cnt == -3 || d_amb_cnt == -4 || d_amb_cnt == -5) then {
+	//adaptive group count
+	//calculate number of ambush groups by counting the number of building in the maintarget area * spawn factor
+	private _amb_spawn_factor = 0;
+	if (d_amb_cnt == -1) then {
+		_amb_spawn_factor = 0.03;  // adaptive (low)
+	};
+	if (d_amb_cnt == -2) then {
+		_amb_spawn_factor = 0.06;  // adaptive (normal)
+	};
+	if (d_amb_cnt == -3) then {
+		_amb_spawn_factor = 0.12;  // adaptive (high)
+	};
+	if (d_amb_cnt == -4) then {
+		_amb_spawn_factor = 0.20;  // adaptive (very high)
+	};
+	if (d_amb_cnt == -5) then {
+		_amb_spawn_factor = 0.85;  // adaptive (extreme)
+	};
+	private _bldg_count = count ([_trg_center, d_amb_rad] call d_fnc_getbldgswithpositions);
+	private _amb_cnt_max = floor(_amb_spawn_factor * 100);
+	d_amb_cnt_current = floor (_bldg_count * _amb_spawn_factor) min _amb_cnt_max;
+	diag_log [format ["_amb_cnt adaptive value: %1", d_amb_cnt_current]];
+} else {
+	d_amb_cnt_current = d_amb_cnt;
+};
+
 // if selected use this array to override with mercenary units (only for Altis and Malden, nice weapons but no body armor)
 private _merc_array = [
 	["East","OPF_G_F","Infantry","O_G_InfSquad_Assault"] call d_fnc_GetConfigGroup,
@@ -590,37 +676,9 @@ if (d_civ_vehs_type > 0) then {
 
 if (d_occ_bldgs == 1 && {!d_preemptive_special_event}) then {
 	//create garrisoned "occupy" groups of AI (free to move immediately)
-	private _occ_cnt = 0;
-	if (d_occ_cnt == -1 || d_occ_cnt == -2 || d_occ_cnt == -3 || d_occ_cnt == -4 || d_occ_cnt == -5) then {
-		//adaptive group count
-		//calculate number of occupy groups by counting the number of building in the maintarget area * spawn factor
-		private _occ_spawn_factor = 0;
-		if (d_occ_cnt == -1) then {
-			_occ_spawn_factor = 0.03;  // adaptive (low)
-		};
-		if (d_occ_cnt == -2) then {
-			_occ_spawn_factor = 0.06;  // adaptive (normal)
-		};
-		if (d_occ_cnt == -3) then {
-			_occ_spawn_factor = 0.12;  // adaptive (high)
-		};
-		if (d_occ_cnt == -4) then {
-			_occ_spawn_factor = 0.20;  // adaptive (very high)
-		};
-		if (d_occ_cnt == -5) then {
-			_occ_spawn_factor = 0.75;  // adaptive (extreme)
-		};
-		private _bldg_count = count ([_trg_center, d_occ_rad] call d_fnc_getbldgswithpositions);
-		private _occ_cnt_max = floor(_occ_spawn_factor * 100);
-		_occ_cnt = floor (_bldg_count * _occ_spawn_factor) min _occ_cnt_max;
-		diag_log [format ["_occ_cnt adaptive value: %1", _occ_cnt]];
-	} else {
-		_occ_cnt = d_occ_cnt;
-	};
-	
-	__TRACE_1("creating occupy groups _occ_cnt","_occ_cnt")
-	if (_occ_cnt > 0) then {
-		for "_xx" from 0 to (_occ_cnt - 1) do {
+	__TRACE_1("creating occupy groups d_occ_cnt_current","d_occ_cnt_current")
+	if (d_occ_cnt_current > 0) then {
+		for "_xx" from 0 to (d_occ_cnt_current - 1) do {
 			private _unitstog = [
 				[[[_trg_center, d_occ_rad]],[]] call BIS_fnc_randomPos,
 				-1,     //_maxNumUnits
@@ -636,36 +694,9 @@ if (d_occ_bldgs == 1 && {!d_preemptive_special_event}) then {
 	};
 	
 	//create garrisoned "overwatch" groups of AI (movement disabled)
-	private _ovrw_cnt = 0;
-	if (d_ovrw_cnt == -1 || d_ovrw_cnt == -2 || d_ovrw_cnt == -3 || d_ovrw_cnt == -4 || d_ovrw_cnt == -5) then {
-		//adaptive group count
-		//calculate number of overwatch groups by counting the number of building in the maintarget area * spawn factor
-		private _ovrw_spawn_factor = 0;
-		if (d_ovrw_cnt == -1) then {
-			_ovrw_spawn_factor = 0.03;  // adaptive (low)
-		};
-		if (d_ovrw_cnt == -2) then {
-			_ovrw_spawn_factor = 0.06;  // adaptive (normal)
-		};
-		if (d_ovrw_cnt == -3) then {
-			_ovrw_spawn_factor = 0.12;  // adaptive (high)
-		};
-		if (d_ovrw_cnt == -4) then {
-			_ovrw_spawn_factor = 0.20;  // adaptive (very high)
-		};
-		if (d_ovrw_cnt == -5) then {
-			_ovrw_spawn_factor = 0.75;  // adaptive (extreme)
-		};
-		private _bldg_count = count ([_trg_center, d_ovrw_rad] call d_fnc_getbldgswithpositions);
-		private _ovrw_cnt_max = floor(_ovrw_spawn_factor * 100);
-		_ovrw_cnt = floor (_bldg_count * _ovrw_spawn_factor) min _ovrw_cnt_max;
-		diag_log [format ["_ovrw_cnt adaptive value: %1", _ovrw_cnt]];
-	} else {
-		_ovrw_cnt = d_ovrw_cnt;
-	};
-	diag_log [format ["creating overwatch groups _ovrw_cnt: %1", _ovrw_cnt]];
-	if (_ovrw_cnt > 0) then {
-		for "_xx" from 0 to (_ovrw_cnt - 1) do {
+	diag_log [format ["creating overwatch groups d_ovrw_cnt_current: %1", d_ovrw_cnt_current]];
+	if (d_ovrw_cnt_current > 0) then {
+		for "_xx" from 0 to (d_ovrw_cnt_current - 1) do {
 			private _unitstog = [
 				[[[_trg_center, d_ovrw_rad]],[]] call BIS_fnc_randomPos,
 				-1,     //_maxNumUnits
@@ -681,36 +712,9 @@ if (d_occ_bldgs == 1 && {!d_preemptive_special_event}) then {
 	};
 
 	//create garrisoned "ambush" groups of AI (free to move after firedNear is triggered)
-	private _amb_cnt = 0;
-	if (d_amb_cnt == -1 || d_amb_cnt == -2 || d_amb_cnt == -3 || d_amb_cnt == -4 || d_amb_cnt == -5) then {
-		//adaptive group count
-		//calculate number of ambush groups by counting the number of building in the maintarget area * spawn factor
-		private _amb_spawn_factor = 0;
-		if (d_amb_cnt == -1) then {
-			_amb_spawn_factor = 0.03;  // adaptive (low)
-		};
-		if (d_amb_cnt == -2) then {
-			_amb_spawn_factor = 0.06;  // adaptive (normal)
-		};
-		if (d_amb_cnt == -3) then {
-			_amb_spawn_factor = 0.12;  // adaptive (high)
-		};
-		if (d_amb_cnt == -4) then {
-			_amb_spawn_factor = 0.20;  // adaptive (very high)
-		};
-		if (d_amb_cnt == -5) then {
-			_amb_spawn_factor = 0.85;  // adaptive (extreme)
-		};
-		private _bldg_count = count ([_trg_center, d_amb_rad] call d_fnc_getbldgswithpositions);
-		private _amb_cnt_max = floor(_amb_spawn_factor * 100);
-		_amb_cnt = floor (_bldg_count * _amb_spawn_factor) min _amb_cnt_max;
-		diag_log [format ["_amb_cnt adaptive value: %1", _amb_cnt]];
-	} else {
-		_amb_cnt = d_amb_cnt;
-	};
-	diag_log [format ["creating ambush groups _amb_cnt: %1", _amb_cnt]];
-	if (_amb_cnt > 0) then {
-		for "_xx" from 0 to (_amb_cnt - 1) do {
+	diag_log [format ["creating ambush groups d_amb_cnt_current: %1", d_amb_cnt_current]];
+	if (d_amb_cnt_current > 0) then {
+		for "_xx" from 0 to (d_amb_cnt_current - 1) do {
 			private _pos = [[[_trg_center, d_amb_rad]],[]] call BIS_fnc_randomPos;
 			// create an ambush group
 			private _unitstog = [


### PR DESCRIPTION
added: civilians move back to starting position after threaten cooldown completes (if threatened to move too far from start position)

fixed: preemptive event correctly applies adaptive group counts