### PR TITLE
fix preemptive cleanup bug

### DIFF
--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_defend.sqf
@@ -68,6 +68,7 @@ private _markerpos = [];
 		_x_mt_event_ar pushBack _x;
 	} forEach _units;
 	_newgroups_inf pushBack _newgroup;
+	d_delinfsm append _units;
 	if (d_with_dynsim == 0) then {
 		[_newgroup, 0] spawn d_fnc_enabledynsim;
 	};
@@ -94,11 +95,7 @@ private _markerpos = [];
 _marker = ["d_mt_event_marker_guerrillainfantry_defend", _markerpos, "ICON","ColorBlack", [1, 1], localize "STR_DOM_MISSIONSTRING_GUERRILLAS", 0, "mil_start"] call d_fnc_CreateMarkerGlobal;
 [_marker, "STR_DOM_MISSIONSTRING_GUERRILLAS"] remoteExecCall ["d_fnc_setmatxtloc", [0, -2] select isDedicated];
 
-private _all_dead = false;
-while {sleep 1; !d_mt_done && {!_all_dead}} do {
-	_foundAlive = _newgroups_inf findIf {(units _x) findIf {alive _x} > -1} > -1;
-	_all_dead = !_foundAlive;
-};
+waitUntil {sleep 1; d_mt_radio_down && {d_mt_done}};
 
 d_mt_event_messages_array deleteAt (d_mt_event_messages_array find _eventDescription);
 publicVariable "d_mt_event_messages_array";
@@ -106,5 +103,4 @@ publicVariable "d_mt_event_messages_array";
 //cleanup
 diag_log [format ["cleanup of event: %1", _mt_event_key]];
 diag_log [format ["cleanup of event array: %1", _x_mt_event_ar]];
-_x_mt_event_ar call d_fnc_deletearrayunitsvehicles;
 deleteMarker _marker;

--- a/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
+++ b/co30_Domination.Altis/missions/events/fn_event_guerrilla_infantry_incoming.sqf
@@ -48,7 +48,7 @@ private _trigger = [_target_center, [d_cur_target_radius,d_cur_target_radius,0,f
 if (d_preemptive_special_event) then {
 	_townNearbyName = "nearby";
 } else {
-	waitUntil {sleep 0.1; !isNil {_trigger getVariable "d_event_start"}};
+	waitUntil {sleep 1; !isNil {_trigger getVariable "d_event_start"}};
 };
 
 private _eventDescription = format [localize "STR_DOM_MISSIONSTRING_2028_INFANTRY", _townNearbyName];
@@ -129,6 +129,8 @@ if (_with_vehicles) then {
     	};
     	_x_mt_event_ar append (_vecs_and_crews # 0); // vehicles
     	_x_mt_event_ar append (_vecs_and_crews # 1); // crews
+    	d_delvecsmt append (_vecs_and_crews # 0);
+		d_delinfsm append (_vecs_and_crews # 1);
 		{
 			_x setSkill ["courage", 1];
 			_x setSkill ["commanding", 1];
@@ -164,6 +166,7 @@ private _guerrillaBaseSkill = 0.85;
 		_x addEventHandler ["handleHeal", {call d_fnc_handleheal}];
 	} forEach _units;
 	_newgroups_inf pushBack _newgroup;
+	d_delinfsm append _units;
 	if (d_with_dynsim == 0) then {
 		[_newgroup, 0] spawn d_fnc_enabledynsim;
 	};
@@ -222,21 +225,9 @@ while {sleep 1; !d_mt_done && {!_all_dead}} do {
 d_mt_event_messages_array deleteAt (d_mt_event_messages_array find _eventDescription);
 publicVariable "d_mt_event_messages_array";
 
-deleteVehicle _trigger;
-deleteMarker _marker;
-
-if (d_preemptive_special_event) then {
-	diag_log [format ["quick cleanup of preemptive event: %1", _mt_event_key]];
-} else {
-	diag_log [format ["waiting for cleanup of preemptive event: %1", _mt_event_key]];
-	if (d_ai_persistent_corpses == 0) then {
-		waitUntil {sleep 10; d_mt_done};
-	} else {
-		sleep 120;
-	};
-};
+waitUntil {sleep 1; d_mt_radio_down && {d_mt_done}};
 
 //cleanup
 diag_log [format ["cleanup of event: %1", _mt_event_key]];
-diag_log [format ["cleanup of event array: %1", _x_mt_event_ar]];
-_x_mt_event_ar call d_fnc_deletearrayunitsvehicles;
+deleteVehicle _trigger;
+deleteMarker _marker;

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -160,7 +160,7 @@ if (d_camp_enable_guard == 1) then {
 #ifndef __TT__
 if (d_side_enemy == opfor && {d_with_MainTargetEvents == -3 || d_with_MainTargetEvents == -5}) then {
 	// chance of a pre-emptive event (a special event which supersedes most maintarget setup) or when d_with_MainTargetEvents == -5
-	if (20 > random 100 || {d_with_MainTargetEvents == -5}) then {
+	if (50 > random 100 || {d_with_MainTargetEvents == -5}) then {
 		diag_log ["Small chance for special event was selected or d_with_MainTargetEvents == -5, d_preemptive_special_event set to true"];
 		d_preemptive_special_event = true;
 		publicVariable "d_preemptive_special_event";		

--- a/co30_Domination.Altis/server/fn_endmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_endmaintarget.sqf
@@ -5,11 +5,7 @@
 if (time - d_last_admin_mt_end < 120) exitWith {
 	diag_log ["not enough time has elapsed to force end the mt event"];
 };
-if (d_preemptive_special_event) exitWith {
-	diag_log ["cannot force end the mt event when a preemptive event is running"];
-};
 d_last_admin_mt_end = time;
-
 d_mt_radio_down = true;
 d_campscaptured = d_sum_camps;
 if (d_ao_markers == 1) then {

--- a/co30_Domination.Altis/server/fn_mchelper.sqf
+++ b/co30_Domination.Altis/server/fn_mchelper.sqf
@@ -16,5 +16,7 @@ while {lineIntersects [ATLToASL _start, ATLToASL _pos]} do {
 };
 _this setPosATL _pos;
 
+sleep (3 + random 2);
+
 _this allowDamage true;
 _this setDamage 0;

--- a/co30_Domination.Altis/server/fn_target_clear.sqf
+++ b/co30_Domination.Altis/server/fn_target_clear.sqf
@@ -252,12 +252,12 @@ if (d_enable_civs == 1) then {
 	private _tmpCivVehs = +d_cur_tgt_civ_vehicles;
 	d_cur_tgt_civ_vehicles = [];
 	
-	[_tmpCivVehs] spawn {
+	[_tmpCivVehs, _cur_tgt_name] spawn {
 		scriptName "spawn_delete_civ_vehicles";
-		params ["_tmpCivVehs"];
+		params ["_tmpCivVehs", "_cur_tgt_name"];
 		diag_log ["pausing (sleep 300) before deleting civ vehicles"];
 		sleep 300;
-		diag_log [format ["pause (sleep 300) is over, now deleting %1 civ vehicles", count _tmpCivVehs]];
+		diag_log [format ["pause (sleep 300) is over, now deleting %1 civ vehicles from completed target %2", count _tmpCivVehs, _cur_tgt_name]];
 		{
 			deleteVehicle _x;
 		} forEach _tmpCivVehs;


### PR DESCRIPTION
fixed: preemptive event cleanup not working when persistent corpses is enabled
fixed: admin may use end maintarget function when a preemptive event is running
fixed: if guerrilla events are enabled there is a 50/50 chance for a preemptive (defense) event