### PR TITLE
see list

### DIFF
--- a/co30_Domination.Altis/client/fn_createdomusermenu.sqf
+++ b/co30_Domination.Altis/client/fn_createdomusermenu.sqf
@@ -115,3 +115,13 @@ if (d_with_ranked && {d_transf_allow == 0}) then {
 		d_DomUserMenu pushBack [localize "STR_DOM_MISSIONSTRING_1880", [call _fnc_inc_num], "", -5, [["expression", "99 call d_fnc_DomCommandingMenuExec"]], "1", "1"];
 	};
 };
+
+if (!d_with_ranked) then {
+	// create uav
+	d_DomUserMenu pushBack [localize "STR_DOM_MISSIONSTRING_1327a", [call _fnc_inc_num], "", -5, [["expression", "60 call d_fnc_DomCommandingMenuExec"]], "1", "1"];
+};
+
+if (!d_with_ranked && {d_player_can_call_arti > 0 && {d_enable_extra_cas == 1}}) then {
+	// create combat uav
+	d_DomUserMenu pushBack [localize "STR_DOM_MISSIONSTRING_1327b", [call _fnc_inc_num], "", -5, [["expression", "70 call d_fnc_DomCommandingMenuExec"]], "1", "1"];
+};

--- a/co30_Domination.Altis/client/fn_domcommandingmenuexec.sqf
+++ b/co30_Domination.Altis/client/fn_domcommandingmenuexec.sqf
@@ -55,6 +55,8 @@ call {
 			d_commandingMenuIniting = false;
 		};
 	};
+	if (_this == 60) exitWith {d_commandingMenuCode = {call d_fnc_makeuav;d_commandingMenuIniting = false}};
+	if (_this == 70) exitWith {d_commandingMenuCode = {call d_fnc_makeuav_combat;d_commandingMenuIniting = false}};
 	if (_this == 99) exitWith {
 		d_commandingMenuCode = {
 			0 spawn {

--- a/co30_Domination.Altis/client/fn_makeuav_combat.sqf
+++ b/co30_Domination.Altis/client/fn_makeuav_combat.sqf
@@ -59,6 +59,8 @@ _vecu allowCrewInImmobile true;
 _vecu setVehicleReceiveRemoteTargets true;
 _vecu setVehicleReportRemoteTargets true;
 _vecu setVehicleRadar 1;
+_vecu disableAI "LIGHTS";
+_vecu setCollisionLight false;
 
 //_vecu allowDamage false;
 
@@ -70,9 +72,12 @@ private _loiter_pos = getPos player;
 if !(d_cur_tgt_pos isEqualTo []) then {
 	_loiter_pos = d_cur_tgt_pos;
 };
+_vecu setVariable["d_loiter_pos", _loiter_pos, true];
+
+// set loiter waypoint
 private _loiter_radius = 800;
 if (d_cur_target_radius > 0) then {
-	_loiter_radius = d_cur_target_radius + 800;
+	_loiter_radius = d_cur_target_radius + 500;
 };
 _wp = _grp addWaypoint [_loiter_pos, 0];
 _wp setWaypointType "LOITER";
@@ -81,7 +86,7 @@ _wp setWaypointLoiterRadius _loiter_radius;
 _wp setWaypointBehaviour "CARELESS";
 _wp setWaypointCombatMode "BLUE";
 
-_vecu flyInHeight 2000;
+_vecu flyInHeight 1100; // this flyInHeight value is only possible with scripting, user selectable values are limited to 250m, 500m, 2000m
 
 player connectTerminalToUav _vecu;
 

--- a/co30_Domination.Altis/client/fn_setupplayer.sqf
+++ b/co30_Domination.Altis/client/fn_setupplayer.sqf
@@ -87,6 +87,8 @@ d_can_call_drop_ar = [];
 d_can_call_cas = [d_string_player];
 #endif
 
+d_player_can_call_extended_ordnance = d_enable_extra_cas;
+
 d_arsenal_opened = false;
 
 player disableConversation true;

--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -1422,9 +1422,9 @@ class Params {
 	
 	class d_snp_aware {
 		title = "$STR_DOM_MISSIONSTRING_1900D";
-		values[] = {0,1};
+		values[] = {0,1,100,200,300,400,500,600,700,800,900,1000,1100,1200,1300,1400,1500,1600,1700,1800,1900,2000};
 		default = 0;
-		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922"};
+		texts[] = {"$STR_DOM_MISSIONSTRING_1007","$STR_DOM_MISSIONSTRING_922","100m","200m","300m","400m","500m","600m","700m","800m","900m","1000m","1100m","1200m","1300m","1400m","1500m","1600m","1700m","1800m","1900m","2000m"};
 	};
 	
 	class d_ai_pursue_rad {

--- a/co30_Domination.Altis/init/d_bldg_blacklist_civs.sqf
+++ b/co30_Domination.Altis/init/d_bldg_blacklist_civs.sqf
@@ -67,5 +67,7 @@
 "scf_01_feeder_f.p3d",
 "pila.p3d",
 "d_stone_shed_v1_f.p3d",
+"i_stone_shed_v1_f.p3d",
 "d_house_small_01_v1_f.p3d",
+"d_house_small_02_v1_f.p3d",
 "unfinished_building_02_f.p3d"

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -3544,6 +3544,7 @@ if (hasInterface) then {
 	d_scoreadd_script = scriptNull;
 	d_weap_hash = createHashMap;
 	d_cur_inv_o_gear = [];
+	d_player_can_call_extended_ordnance = 0;
 
 	d_virtual_entities = ["d_virt_man_1", "d_virt_man_2", "d_virt_man_3", "d_virt_man_4", "d_virt_man_5"];
 

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -168,7 +168,13 @@ if !(isNull _targetBuilding) then {
 private _buildingPosArray = [];
 
 {
-	_buildingPosArray pushBack (_x buildingPos -1);
+	private _parray = _x buildingPos -1;
+	// some buildings in the safe list have one or more bad position, remove bad positions here
+	if (["chapel_v1_f", toLowerANSI (getModelInfo _x # 0)] call BIS_fnc_inString) then {
+		_parray deleteAt 1;
+	};
+	// add positions
+	_buildingPosArray pushBack _parray;
 } forEach _buildingsArrayFiltered;
 
 __TRACE_1("","_buildingPosArray")

--- a/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness_global.sqf
+++ b/co30_Domination.Altis/scripts/fn_hallyg_dlegion_Snipe_awareness_global.sqf
@@ -18,8 +18,12 @@ __TRACE_1("","_this")
 
 private _isSniper = _unit getVariable ["d_is_sniper", false];
 
-if (_isSniper && { d_snp_aware == 1 }) then {
-	_awarenessRadius = 1200;
+if (_isSniper && { d_snp_aware > 0 }) then {
+	if (d_snp_aware == 1) then {
+		_awarenessRadius = 1200; // awareness distance with the old default property value (0 or 1)
+	} else {
+		_awarenessRadius = d_snp_aware;
+	};
 };
 
 if (_awarenessRadius <= 0) exitWith {};
@@ -162,7 +166,11 @@ if (_Dtargets isNotEqualTo []) then {
 					// execute aggressive shooting
 					_isDoingSuppressiveFire = true;
 					_unit doTarget _x;
-					_unit doSuppressiveFire (getPosASL _x);
+					if (_isSniper) then {
+						_unit doFire _x; // sniper should only fire once
+					} else {
+						_unit doSuppressiveFire (getPosASL _x);
+					};
 				};
 			} forEach _targets;
 		};

--- a/co30_Domination.Altis/server/fn_civilianmodule.sqf
+++ b/co30_Domination.Altis/server/fn_civilianmodule.sqf
@@ -98,12 +98,17 @@ private _safe_building_strings = [
 private _blacklist_building_strings = [
 	"slum_",
 	"shed_",
-	"Land_d",
-	"Land_u",
+	"d_house_small",
+	"d_house_big",
+	"u_house_small",
+	"u_house_big",
+	"u_shop",
+	"i_stone_housebig",
 	"factory",
 	"fuel",
 	"reservoir",
 	"warehouse",
+	"pier",
 	"Land_SCF",
 	"Land_SM"];
 

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -137,8 +137,7 @@ _merc_array = [
 	["East","OPF_G_F","Infantry","O_G_InfSquad_Assault"] call d_fnc_GetConfigGroup,
 	["East","OPF_G_F","Infantry","O_G_InfSquad_Assault"] call d_fnc_GetConfigGroup,
 	["East","OPF_G_F","Infantry","O_G_InfTeam_Light"] call d_fnc_GetConfigGroup,
-	["East","OPF_G_F","Infantry","O_G_InfTeam_Light"] call d_fnc_GetConfigGroup,
-	["East","OPF_F","Infantry","OIA_InfTeam_AA"] call d_fnc_GetConfigGroup
+	["East","OPF_G_F","Infantry","O_G_InfTeam_Light"] call d_fnc_GetConfigGroup
 ];
 #endif
 #ifdef __OWN_SIDE_OPFOR__
@@ -146,8 +145,7 @@ _merc_array = [
 	["West","Guerilla","Infantry","IRG_InfSquad"] call d_fnc_GetConfigGroup,
 	["West","Guerilla","Infantry","IRG_InfSquad"] call d_fnc_GetConfigGroup,
 	["West","Guerilla","Infantry","IRG_InfSquad_Weapons"] call d_fnc_GetConfigGroup,
-	["West","Guerilla","Infantry","IRG_InfSquad_Weapons"] call d_fnc_GetConfigGroup,
-	["West","BLU_F","Infantry","BUS_InfTeam_AA"] call d_fnc_GetConfigGroup
+	["West","Guerilla","Infantry","IRG_InfSquad_Weapons"] call d_fnc_GetConfigGroup
 ];
 #endif
 

--- a/co30_Domination.Altis/server/fn_createsecondary.sqf
+++ b/co30_Domination.Altis/server/fn_createsecondary.sqf
@@ -155,7 +155,7 @@ if (d_ao_check_for_ai in [0, 1]) then {
 
 	private _isFirstCamp = true;
 
-	private _parray = [_trg_center, d_cur_target_radius + 200, 5, 0.3, 0, false, true] call d_fnc_GetRanPointCircleBigArray;
+	private _parray = [_trg_center, d_cur_target_radius + (0.666 * d_cur_target_radius), 5, 0.3, 0, false, true] call d_fnc_GetRanPointCircleBigArray;
 
 	for "_i" from 1 to _nrcamps do {
 		private _wf = objNull;
@@ -304,7 +304,7 @@ if (d_ao_check_for_ai in [0, 1]) then {
 
 sleep 0.1;
 
-if (d_with_minefield == 0 && {random 100 > 80}) then {
+if (d_with_minefield == 0 && {!d_preemptive_special_event && {random 100 > 80}}) then {
 	[_mtradius, _trg_center] call d_fnc_minefield;
 };
 

--- a/co30_Domination.Altis/server/fn_uav_loop.sqf
+++ b/co30_Domination.Altis/server/fn_uav_loop.sqf
@@ -14,13 +14,10 @@ while {true} do {
 			publicVariable "d_cur_uav_combat";
 			deleteVehicle _x;
 		} else {
-			diag_log [_x getVariable "d_loiter_pos"];
-			diag_log [d_cur_tgt_pos];
 			if (d_cur_tgt_pos isNotEqualTo [] && {(_x getVariable "d_loiter_pos") isNotEqualTo d_cur_tgt_pos}) then {
 				diag_log ["maintarget pos has changed, moving combat UAV to new maintarget"];
 				private _loiter_pos = d_cur_tgt_pos;
 				private _grp = group _x;
-				diag_log [groupId _grp];
 				// set loiter waypoint
 				private _loiter_radius = 800;
 				if (d_cur_target_radius > 0) then {

--- a/co30_Domination.Altis/server/fn_uav_loop.sqf
+++ b/co30_Domination.Altis/server/fn_uav_loop.sqf
@@ -13,7 +13,43 @@ while {true} do {
 			d_cur_uav_combat deleteAt (d_cur_uav_combat find _x);
 			publicVariable "d_cur_uav_combat";
 			deleteVehicle _x;
+		} else {
+			diag_log [_x getVariable "d_loiter_pos"];
+			diag_log [d_cur_tgt_pos];
+			if (d_cur_tgt_pos isNotEqualTo [] && {(_x getVariable "d_loiter_pos") isNotEqualTo d_cur_tgt_pos}) then {
+				diag_log ["maintarget pos has changed, moving combat UAV to new maintarget"];
+				private _loiter_pos = d_cur_tgt_pos;
+				private _grp = group _x;
+				diag_log [groupId _grp];
+				// set loiter waypoint
+				private _loiter_radius = 800;
+				if (d_cur_target_radius > 0) then {
+					_loiter_radius = d_cur_target_radius + 500;
+				};
+				
+				// must first order MOVE before LOITER for some reason...
+				deleteWaypoint [_grp, 1];
+				_wp = _grp addWaypoint [_loiter_pos, 1];
+				_wp setWaypointType "MOVE";
+				_wp setWaypointBehaviour "CARELESS";
+				_wp setWaypointCombatMode "BLUE";
+				_grp setCurrentWaypoint [_grp, 1];
+				
+				sleep 3;
+				
+				// order LOITER
+				deleteWaypoint [_grp, 2];
+				_wp = _grp addWaypoint [_loiter_pos, 2];
+				_wp setWaypointType "LOITER";
+				_wp setWaypointLoiterType "CIRCLE_L";
+				_wp setWaypointLoiterRadius _loiter_radius;
+				_wp setWaypointBehaviour "CARELESS";
+				_wp setWaypointCombatMode "BLUE";
+				_grp setCurrentWaypoint [_grp, 2];
+				
+				_x setVariable["d_loiter_pos", _loiter_pos, true];
+			};
 		};
 	} forEach d_cur_uav_combat;
-	sleep 7;	
+	sleep 7;
 };


### PR DESCRIPTION
added: if server is unranked then players can create a UAV anywhere (not restricted to a deployed MHQ)
added: if server is unranked and extra ordnance is enabled then players can create a combat UAV anywhere (not restricted to a deployed MHQ)
added: combat UAV will reposition to new maintarget when previous target in cleared
added: d_snp_aware is now a configurable distance, 0 no awareness, 1 is unchanged (1200m like before) or awareness is set by property value 100m-2000m
added: camp radius is relative to target radius (was static at 200m)
fixed: combat UAV loiters closer to maintarget, altitude lowered from 2000m to 1100m, vehicle lights are off
fixed: remove the AA teams from 2035 mercenaries
fixed: no mines during preemptive event
fixed: fewer total civilian clusters were being created than expected
added: better blacklist for spawning civilians in buildings

also changed sniper from `doSuppressiveFire` to `doFire` so they only fire one shot when player is spotted
might revert back to `doSuppressiveFire` later if this change makes the snipers too inaccurate