### PR TITLE
support for mods - Project injury reaction and Death and hit reactions

### DIFF
--- a/co30_Domination.Altis/description.ext
+++ b/co30_Domination.Altis/description.ext
@@ -327,6 +327,15 @@ class CfgRemoteExec {
 		class globalRadio {};
 		class setVehicleAmmo {};
 #endif
+		// support for mod - Project injury reaction (PiR)
+		class switchmove {};
+		class playactionnow {};
+		class setanimspeedcoef {};
+		class pir {};
+		// support for mod - Death and hit reactions
+		class setbleedingremaining {};
+		class call {};  // strange name for a function...
+		class bis_fnc_effectkilled {};
 	};
 };
 

--- a/co30_Domination.Altis/init/fn_preinit.sqf
+++ b/co30_Domination.Altis/init/fn_preinit.sqf
@@ -3926,4 +3926,16 @@ if (d_guerrilla_factions > 0) then {
 		};
 	};
 };
+// support for mod - Death and hit reactions
+// this should not be required but something was wrong with initializing CBA properties for DAH with Domination, this fixed it
+WBK_DAH_Deaths_EnableFor_PLAYERS = false;
+WBK_DAH_Deaths_EnableFor_AI = true;
+WBK_DAH_Death_Chance = 100;
+WBK_DAH_Hit_EnableFor_AI = true;
+WBK_DAH_Hit_EnableFor_PLAYERS = false;
+WBK_DAH_Hit_Chance = 100;
+WBK_DAH_Hit_Chance_PLR = 0;
+WBK_DAH_Flinch_EnableFor_AI = false;
+WBK_DAH_Flinch_EnableFor_PLAYERS = false;
+
 diag_log [diag_frameno, diag_ticktime, time, "Dom fn_preinit.sqf processed"];

--- a/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
+++ b/co30_Domination.Altis/scripts/fn_Zen_OccupyHouse.sqf
@@ -150,6 +150,21 @@ _spawn_script_enable_movement = {
 	};
 };
 
+_check_vertical_jumps = {
+	params ["_uuidx"];
+	_uuidx spawn {
+		scriptName "check if unit is vertically jumping and delete if true";
+		sleep 3;
+		private _startposz = (getPosASL _this) select 2;
+		sleep 3; 
+		private _posz = (getPosASL _this) select 2;
+		if (_posz != _startposz) exitWith {
+			// found a jumper (unit hovers up and down)
+			deleteVehicle _this;
+		};
+	};
+};
+
 private _buildingsArrayFiltered = [];
 
 // use targetBuilding if it was passed
@@ -355,6 +370,8 @@ __TRACE("start of forEach _buildingPosArray")
 											_uuidx setDir _i;
 		
 											doStop _uuidx;
+											[_uuidx] call _check_vertical_jumps;
+											_uuidx 
 										};
 		
 										//occupy mode - no special behavior

--- a/co30_Domination.Altis/scripts/fn_createsimpleobject.sqf
+++ b/co30_Domination.Altis/scripts/fn_createsimpleobject.sqf
@@ -85,7 +85,11 @@ private _superSimple = _class == "" || {_forceSuperSimple};
 private _object = nil;
 if (_superSimple) then {
 	//World coords are used
-	_object = createSimpleObject [_p3d, _pos, _loc];
+	if (d_EnableSimulationCamps > 0) then {
+		_object = createVehicle [_p3d, _pos, [], 0, "NONE"];
+	} else {
+		_object = createSimpleObject [_p3d, _pos, _loc];
+	};
 } else {
 	if (d_EnableSimulationCamps > 0) then {
 		_object = createVehicle [_class, _pos, [], 0, "NONE"];

--- a/co30_Domination.Altis/server/fn_createmaintarget.sqf
+++ b/co30_Domination.Altis/server/fn_createmaintarget.sqf
@@ -219,24 +219,22 @@ if (d_side_enemy == opfor && {d_with_MainTargetEvents == -3 || d_with_MainTarget
 };
 #endif
 
-if (_camp_enable_guard_current == 1) then {
-	_type_list_guard = [
-		["allmen", 0, [d_footunits_guard, 0] call _selectitmen],
-		["specops", 0, [d_footunits_guard, 1] call _selectitmen],
-		["tank", [d_vec_numbers_guard, 0] call _selectit, [d_vec_numbers_guard,0] call _selectitvec],
-		["tracked_apc", [d_vec_numbers_guard, 1] call _selectit, [d_vec_numbers_guard,1] call _selectitvec],
-		["wheeled_apc", [d_vec_numbers_guard, 2] call _selectit, [d_vec_numbers_guard,2] call _selectitvec],
-		["jeep_mg", [d_vec_numbers_guard, 3] call _selectit, [d_vec_numbers_guard,3] call _selectitvec],
-		["jeep_gl", [d_vec_numbers_guard, 4] call _selectit, [d_vec_numbers_guard,4] call _selectitvec]
-	];
-	_type_list_guard_static = [
-		["allmen", 0, [d_footunits_guard_static, 0] call _selectitmen],
-		["specops",0, [d_footunits_guard_static, 1] call _selectitmen],
-		["tank", [d_vec_numbers_guard_static, 0] call _selectit, [d_vec_numbers_guard_static,0] call _selectitvec],
-		["tracked_apc", [d_vec_numbers_guard_static, 1] call _selectit, [d_vec_numbers_guard_static,1] call _selectitvec],
-		["aa", [d_vec_numbers_guard_static, 2] call _selectit, [d_vec_numbers_guard_static,2] call _selectitvec]
-	];
-};
+_type_list_guard = [
+	["allmen", 0, [d_footunits_guard, 0] call _selectitmen],
+	["specops", 0, [d_footunits_guard, 1] call _selectitmen],
+	["tank", [d_vec_numbers_guard, 0] call _selectit, [d_vec_numbers_guard,0] call _selectitvec],
+	["tracked_apc", [d_vec_numbers_guard, 1] call _selectit, [d_vec_numbers_guard,1] call _selectitvec],
+	["wheeled_apc", [d_vec_numbers_guard, 2] call _selectit, [d_vec_numbers_guard,2] call _selectitvec],
+	["jeep_mg", [d_vec_numbers_guard, 3] call _selectit, [d_vec_numbers_guard,3] call _selectitvec],
+	["jeep_gl", [d_vec_numbers_guard, 4] call _selectit, [d_vec_numbers_guard,4] call _selectitvec]
+];
+_type_list_guard_static = [
+	["allmen", 0, [d_footunits_guard_static, 0] call _selectitmen],
+	["specops",0, [d_footunits_guard_static, 1] call _selectitmen],
+	["tank", [d_vec_numbers_guard_static, 0] call _selectit, [d_vec_numbers_guard_static,0] call _selectitvec],
+	["tracked_apc", [d_vec_numbers_guard_static, 1] call _selectit, [d_vec_numbers_guard_static,1] call _selectitvec],
+	["aa", [d_vec_numbers_guard_static, 2] call _selectit, [d_vec_numbers_guard_static,2] call _selectitvec]
+];
 
 private _type_list_patrol = [
 	["allmen", 0, [d_footunits_patrol, 0] call _selectitmen],
@@ -536,7 +534,7 @@ private _comppost = [];
 		for "_xxx" from 1 to (_x # 2) do {
 			private _ppos = [];
 			private _iscompost = false;
-			if (!isNil "d_compositions" && {d_compositions isNotEqualTo [] && {(_x # 0) in ["allmen", "specops"]}}) then {
+			if (_camp_enable_guard_current == 1 && {!isNil "d_compositions" && {d_compositions isNotEqualTo [] && {(_x # 0) in ["allmen", "specops"]}}}) then {
 				_idx = floor random (count _parray);
 				_nppos = _parray # _idx;
 				_ppos = _nppos;
@@ -573,7 +571,7 @@ sleep 0.233;
 		for "_xxx" from 1 to (_x # 2) do {
 			private _ppos = [];
 			private _iscompost = false;
-			if (!isNil "d_compositions" && {d_compositions isNotEqualTo [] && {(_x # 0) in ["allmen", "specops"]}}) then {
+			if (_camp_enable_guard_current == 1 && {!isNil "d_compositions" && {d_compositions isNotEqualTo [] && {(_x # 0) in ["allmen", "specops"]}}}) then {
 				_idx = floor random (count _parray);
 				_nppos = _parray # _idx;
 				_ppos = _nppos;


### PR DESCRIPTION
added: support for mods - Project injury reaction (PiR) and Death and Hit Reactions (DAH)
fixed: disabling static camps was also disabling vehicles
fixed: when d_EnableSimulationCamps is set then enable damage for created objects, for example sandbag emplacements will not be invulnerable to damage
fixed: try to delete units that are hovering by checking Z axis a few times after unit is spawned