### PR TITLE
persist destroyed vehicles when d_ai_persistent_corpses == 0

### DIFF
--- a/co30_Domination.Altis/server/fn_entitykilled.sqf
+++ b/co30_Domination.Altis/server/fn_entitykilled.sqf
@@ -113,7 +113,7 @@ if (_ar # 16 == 1) then {
 	d_sm_arrest_not_failed = false;
 };
 
-if (_ar # 5 == 1) then {
+if (_ar # 5 == 1 && { d_ai_persistent_corpses != 0 }) then {
 	call d_fnc_handleDeadVec;
 };
 

--- a/co30_Domination.Altis/server/fn_makevgroup.sqf
+++ b/co30_Domination.Altis/server/fn_makevgroup.sqf
@@ -25,7 +25,9 @@ for "_n" from 0 to _nnvnum do {
 	};
 	
 	[_vec, 5] call d_fnc_setekmode;
-	addToRemainsCollector [_vec];
+	if (d_ai_persistent_corpses != 0) then {
+		addToRemainsCollector [_vec];
+	};
 	
 	if (_dyna && {d_with_dynsim == 0 && {!unitIsUAV _vec}}) then {
 		[_vec] spawn d_fnc_enabledynsim;


### PR DESCRIPTION
added: destroyed vehicles persist until end of target when d_ai_persistent_corpses == 0